### PR TITLE
fix: harden runtime and UI fallbacks

### DIFF
--- a/.github/codeql/actions-config.yml
+++ b/.github/codeql/actions-config.yml
@@ -1,0 +1,6 @@
+name: Flashbang GitHub Actions
+
+# Workflows fetch remote data, open pull requests, create releases, and publish
+# containers, so include the extended security checks for privileged CI code.
+queries:
+  - uses: security-extended

--- a/.github/codeql/javascript-config.yml
+++ b/.github/codeql/javascript-config.yml
@@ -1,0 +1,20 @@
+name: Flashbang JavaScript and TypeScript
+
+# Keep the default high-precision security queries and add lower-severity and
+# lower-precision security checks. Code quality is already enforced by Biome
+# and TypeScript in CI.
+queries:
+  - uses: security-extended
+
+# Analyze shipped browser/server code and build scripts. Tests, generated bang
+# data, and local profiling code are omitted to focus alerts on attack surface.
+paths:
+  - functions
+  - scripts
+  - src
+  - uno.config.ts
+  - playwright.config.ts
+
+paths-ignore:
+  - scripts/profile.ts
+  - src/generated

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,58 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [master]
+    paths-ignore:
+      - '**/*.md'
+      - '.github/images/**'
+      - 'data/**'
+  pull_request:
+    branches: [master]
+    paths-ignore:
+      - '**/*.md'
+      - '.github/images/**'
+      - 'data/**'
+  schedule:
+    - cron: '37 3 * * 3'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: javascript-typescript
+            config: ./.github/codeql/javascript-config.yml
+          - language: actions
+            config: ./.github/codeql/actions-config.yml
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+          config-file: ${{ matrix.config }}
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        with:
+          category: /language:${{ matrix.language }}

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -31,11 +31,15 @@ bun run clean      # remove dist/
 ```
 flashbang/
 ├── .github/
+│   ├── codeql/
+│   │   ├── actions-config.yml  # Extended CodeQL queries for GitHub Actions
+│   │   └── javascript-config.yml # CodeQL scope and queries for JavaScript/TypeScript
 │   ├── dependabot.yml          # Weekly Bun, GitHub Actions, and Docker updates
 │   ├── images/
 │   │   └── landing.png        # README screenshot
 │   └── workflows/
 │       ├── ci.yaml            # Typecheck, checks, tests, build, and E2E matrix
+│       ├── codeql.yaml         # CodeQL analysis for application and workflow code
 │       ├── release.yaml       # GitHub Release and multi-architecture image publishing
 │       └── update-bangs.yaml  # Daily bang-source refresh
 ├── functions/
@@ -206,7 +210,7 @@ Custom bangs are stored in the `custom-bangs` IndexedDB object store. The UI sup
 
 CSP headers are defined in `src/server/headers.ts` — the single source of truth for all deployment targets. The page CSP and SW CSP differ:
 
-- **Page CSP** — No `unsafe-eval`. The `script-src` value varies by target: `build.ts` uses inline script hashes, while `dev.ts`/`start.ts` use `'unsafe-inline'`
+- **Page CSP** — No `unsafe-eval`. Production targets use inline script hashes; only `dev.ts` uses `'unsafe-inline'` for the live-reload script
 - **SW CSP** — Strict: `default-src 'self'; script-src 'self'; connect-src 'self'`. No `unsafe-eval`; SW runtime avoids eval.
 
 On **Cloudflare Pages**, CSP is set per-path in `_headers` (not `/*`) to avoid CF Pages' additive header merging — `/*` would combine with `/sw.js`, and the browser enforces the intersection. Instead, CSP is set individually on `/`, `/index.html`, `/home.html`, `/bench.html`, and `/sw.js`.

--- a/README.md
+++ b/README.md
@@ -165,14 +165,16 @@ docker run -p 3000:3000 flashbang
 
 To include custom suggestion URLs in a private Docker deployment, build with `docker build --build-arg ALLOW_UNSAFE_CUSTOM_SUGGEST_URLS=true -t flashbang .`. The image uses the same value as its runtime default.
 
-The image uses a multi-stage build — fetches bang sources, builds assets, and produces a minimal runtime image. Static assets are pre-compressed with Brotli at build time and served automatically, falling back to uncompressed for clients that don't support it. The port is configurable via the `PORT` environment variable (`-e PORT=8080`); `PUBLIC_ORIGIN` configures the browser-visible origin when running behind a reverse proxy (for example, `-e PUBLIC_ORIGIN=https://search.example.com`). Set it as your browser's custom search engine:
+The image uses a multi-stage build — fetches bang sources, builds assets, and produces a minimal runtime image. Static assets are pre-compressed with Brotli at build time and served automatically, falling back to uncompressed for clients that don't support it. The port is configurable via the `PORT` environment variable (`-e PORT=8080`); `PUBLIC_ORIGIN` configures the browser-visible origin when running behind a reverse proxy (for example, `-e PUBLIC_ORIGIN=https://search.example.com`).
 
-- **Search URL:** `http://your-host:3000?q=%s`
-- **Suggestion URL:** `http://your-host:3000/suggest?q=%s`
+For a remote deployment, terminate TLS with a reverse proxy or hosting provider and expose Flashbang over HTTPS. Browsers only enable Service Workers in secure contexts (HTTPS or localhost), and Flashbang's suggestion settings cookie is `Secure`. Plain HTTP on a VPS will not provide worker redirects or persistent suggestion settings. Set the HTTPS origin as your browser's custom search engine:
+
+- **Search URL:** `https://search.example.com?q=%s`
+- **Suggestion URL:** `https://search.example.com/suggest?q=%s`
 
 ### Self-host without Docker
 
-Requires [Bun](https://bun.sh). Service Workers need an HTTP origin (not `file://`), but a local server works fine:
+Requires [Bun](https://bun.sh). Service Workers require HTTPS except on `localhost`; a local HTTP server works because browsers treat localhost as a secure context:
 
 ```sh
 bun run codegen && bun run build && bun run start

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -145,8 +145,11 @@ async function main(): Promise<void> {
   console.log("=== Generate _headers with CSP ===");
   function extractScriptHashes(html: string): string[] {
     const hashes: string[] = [];
-    const re = /<script>([\s\S]*?)<\/script>/g;
+    const re = /<script\b[^>]*>([\s\S]*?)<\/script\b[^>]*>/gi;
     for (const match of html.matchAll(re)) {
+      if (!match[1]) {
+        continue;
+      }
       const hash = createHash("sha256").update(match[1]).digest("base64");
       hashes.push(`'sha256-${hash}'`);
     }

--- a/scripts/start.ts
+++ b/scripts/start.ts
@@ -61,7 +61,12 @@ export function cacheControlForAsset(assetPath: string): string {
 
 export function extractInlineScriptHashes(html: string): string[] {
   const hashes: string[] = [];
-  for (const match of html.matchAll(/<script>([\s\S]*?)<\/script>/g)) {
+  for (const match of html.matchAll(
+    /<script\b[^>]*>([\s\S]*?)<\/script\b[^>]*>/gi
+  )) {
+    if (!match[1]) {
+      continue;
+    }
     const hash = createHash("sha256").update(match[1]).digest("base64");
     hashes.push(`'sha256-${hash}'`);
   }

--- a/scripts/start.ts
+++ b/scripts/start.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { normalize } from "node:path";
 import {
   handleOpenSearchRequest,
@@ -6,9 +7,7 @@ import {
 import { pageHeaders, SW_HEADERS } from "../src/server/headers";
 import { readPathname } from "../src/shared/raw-url";
 
-const SECURITY_HEADERS = pageHeaders("'unsafe-inline'");
-const SECURITY_HEADER_ENTRIES: ReadonlyArray<readonly [string, string]> =
-  Object.entries(SECURITY_HEADERS);
+let securityHeaders = pageHeaders("");
 const IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable";
 const REVALIDATE_CACHE_CONTROL = "public, max-age=0, must-revalidate";
 const HASHED_CHUNK_RE = /^\/chunk-[a-z0-9_-]{8,}\.js$/i;
@@ -60,6 +59,15 @@ export function cacheControlForAsset(assetPath: string): string {
     : REVALIDATE_CACHE_CONTROL;
 }
 
+export function extractInlineScriptHashes(html: string): string[] {
+  const hashes: string[] = [];
+  for (const match of html.matchAll(/<script>([\s\S]*?)<\/script>/g)) {
+    const hash = createHash("sha256").update(match[1]).digest("base64");
+    hashes.push(`'sha256-${hash}'`);
+  }
+  return hashes;
+}
+
 export function staticAssetHeaders(
   assetPath: string,
   contentType: string,
@@ -71,7 +79,7 @@ export function staticAssetHeaders(
     "Cache-Control": cacheControlForAsset(assetPath),
     Vary: "Accept-Encoding",
     ...(compressed ? { "Content-Encoding": "br" } : {}),
-    ...SECURITY_HEADERS,
+    ...securityHeaders,
     ...extraHeaders,
   };
 }
@@ -127,6 +135,17 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
+  const pageHtml = await Promise.all(
+    ["index.html", "home.html", "bench.html"].map((name) =>
+      Bun.file(`${DIST_DIR}/${name}`).text()
+    )
+  );
+  const scriptHashes = [
+    ...new Set(pageHtml.flatMap(extractInlineScriptHashes)),
+  ];
+  securityHeaders = pageHeaders(scriptHashes.join(" "));
+  const securityHeaderEntries = Object.entries(securityHeaders);
+
   const staticManifest = buildStaticManifest();
   const port = Number(process.env.PORT) || 3000;
   console.log(`Production server: http://localhost:${port}`);
@@ -137,12 +156,12 @@ async function main(): Promise<void> {
       const pathname = readPathname(req.url);
 
       if (pathname === "/health") {
-        return new Response("ok");
+        return new Response("ok", { headers: securityHeaders });
       }
 
       if (pathname === "/suggest") {
         const res = await handleSuggestRequest(req);
-        for (const [k, v] of SECURITY_HEADER_ENTRIES) {
+        for (const [k, v] of securityHeaderEntries) {
           res.headers.set(k, v);
         }
         return res;
@@ -150,7 +169,7 @@ async function main(): Promise<void> {
 
       if (pathname === "/opensearch.xml") {
         const res = handleOpenSearchRequest(req);
-        for (const [k, v] of SECURITY_HEADER_ENTRIES) {
+        for (const [k, v] of securityHeaderEntries) {
           res.headers.set(k, v);
         }
         return res;
@@ -172,7 +191,7 @@ async function main(): Promise<void> {
       if (!normalized.startsWith(DIST_PREFIX)) {
         return new Response("Not found", {
           status: 404,
-          headers: SECURITY_HEADERS,
+          headers: securityHeaders,
         });
       }
       const fromDist = serveCompressed(

--- a/src/server/headers.ts
+++ b/src/server/headers.ts
@@ -1,4 +1,6 @@
 const BASE_HEADERS: Record<string, string> = {
+  "Permissions-Policy": "camera=(), geolocation=(), microphone=()",
+  "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
   "X-Content-Type-Options": "nosniff",
   "X-Frame-Options": "DENY",
   "Referrer-Policy": "strict-origin-when-cross-origin",
@@ -17,7 +19,7 @@ export function pageHeaders(scriptSrc: string): Record<string, string> {
   return {
     "Content-Security-Policy": [
       "default-src 'self'",
-      `script-src 'self' ${scriptSrc}`,
+      `script-src 'self'${scriptSrc ? ` ${scriptSrc}` : ""}`,
       "style-src 'self' 'unsafe-inline'",
       "connect-src 'self'",
       "img-src 'self' data:",

--- a/src/shared/custom-trigger.ts
+++ b/src/shared/custom-trigger.ts
@@ -1,6 +1,11 @@
 export const MAX_CUSTOM_TRIGGER_LENGTH = 64;
 
-const RESERVED_CUSTOM_TRIGGERS = new Set(["settings"]);
+const RESERVED_CUSTOM_TRIGGERS = new Set([
+  "__proto__",
+  "constructor",
+  "prototype",
+  "settings",
+]);
 const ENCODED_TRIGGER_SEPARATOR = /%(?:20|21|40)/i;
 
 export function validateCustomTrigger(trigger: string): string | null {
@@ -15,6 +20,9 @@ export function validateCustomTrigger(trigger: string): string | null {
   }
   if (trigger.includes("!") || trigger.includes("@") || trigger.includes("+")) {
     return "Shortcut cannot contain !, @, or +";
+  }
+  if (trigger.includes(",") || trigger.includes(":")) {
+    return "Shortcut cannot contain comma or colon";
   }
   if (ENCODED_TRIGGER_SEPARATOR.test(trigger)) {
     return "Shortcut cannot contain encoded separators (%20, %21, or %40)";

--- a/src/shared/frecency-serial.ts
+++ b/src/shared/frecency-serial.ts
@@ -5,7 +5,7 @@ export function serializeFrecencyCompact(
     return "";
   }
   const parts: string[] = [];
-  for (const key in counts) {
+  for (const key of Object.keys(counts)) {
     parts.push(`${key}:${counts[key]}`);
   }
   return parts.join(",");

--- a/src/sw/idb.ts
+++ b/src/sw/idb.ts
@@ -54,6 +54,10 @@ let loadFrecencyPromise: Promise<void> | null = null;
 let topFrecency: TopFrecencyEntry[] = [];
 let lastDecayTs: number = 0;
 
+function emptyFrecencyCounts(): Record<string, number> {
+  return Object.create(null) as Record<string, number>;
+}
+
 export function getCachedSettings(): RedirectSettings | null {
   return cachedRedirect;
 }
@@ -185,7 +189,7 @@ function applyDecay(): void {
     return;
   }
   const factor = 0.5 ** (elapsed / FRECENCY_HALF_LIFE_MS);
-  const pruned: Record<string, number> = {};
+  const pruned = emptyFrecencyCounts();
   for (const key of Object.keys(frecencyCounts)) {
     const decayed = Math.round(frecencyCounts[key] * factor);
     if (decayed >= 1) {
@@ -206,7 +210,11 @@ function pruneFrecency(): void {
   }
   const entries = Object.entries(frecencyCounts);
   entries.sort((a, b) => b[1] - a[1]);
-  frecencyCounts = Object.fromEntries(entries.slice(0, MAX_FRECENCY_ENTRIES));
+  const pruned = emptyFrecencyCounts();
+  for (const [trigger, count] of entries.slice(0, MAX_FRECENCY_ENTRIES)) {
+    pruned[trigger] = count;
+  }
+  frecencyCounts = pruned;
 }
 
 export function hasTopFrecency(): boolean {
@@ -236,17 +244,7 @@ export function loadFrecency(): Promise<void> {
           store.get("frecency")
         );
         const stored = result?.value ?? "";
-        if (stored.charCodeAt(0) === 123) {
-          // '{' = old JSON format (migration)
-          const raw = JSON.parse(stored);
-          if (raw.c && typeof raw.t === "number") {
-            frecencyCounts = raw.c;
-            lastDecayTs = raw.t;
-          } else {
-            frecencyCounts = raw;
-            lastDecayTs = Date.now();
-          }
-        } else if (stored) {
+        if (stored) {
           const pipeIdx = stored.indexOf("|");
           lastDecayTs =
             pipeIdx > 0
@@ -254,10 +252,10 @@ export function loadFrecency(): Promise<void> {
               : Date.now();
           frecencyCounts =
             pipeIdx === -1
-              ? {}
+              ? emptyFrecencyCounts()
               : parseFrecencyCompact(stored.substring(pipeIdx + 1));
         } else {
-          frecencyCounts = {};
+          frecencyCounts = emptyFrecencyCounts();
           lastDecayTs = Date.now();
         }
 
@@ -268,7 +266,7 @@ export function loadFrecency(): Promise<void> {
           : [];
         persistFrecencySnapshot(frecencyCounts, lastDecayTs);
       } catch {
-        frecencyCounts = {};
+        frecencyCounts = emptyFrecencyCounts();
         topFrecency = [];
         lastDecayTs = Date.now();
       }
@@ -282,7 +280,7 @@ export function loadFrecency(): Promise<void> {
 
 export function trackBangUsage(trigger: string) {
   if (!frecencyCounts) {
-    frecencyCounts = {};
+    frecencyCounts = emptyFrecencyCounts();
     topFrecency = [];
   }
   const nextCount = (frecencyCounts[trigger] || 0) + 1;

--- a/src/sw/sw.ts
+++ b/src/sw/sw.ts
@@ -160,14 +160,15 @@ self.addEventListener("install", (e: ExtendableEvent) => {
 });
 
 self.addEventListener("activate", (e: ExtendableEvent) => {
-  void readRedirectSettings();
-  void loadFrecency();
   e.waitUntil(
-    Promise.all([deleteOldCaches(CACHE_NAME), self.clients.claim()]).then(
-      () => {
-        /* no-op */
-      }
-    )
+    Promise.all([
+      deleteOldCaches(CACHE_NAME),
+      self.clients.claim(),
+      readRedirectSettings(),
+      loadFrecency(),
+    ]).then(() => {
+      /* no-op */
+    })
   );
 });
 

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -31,14 +31,17 @@ function init() {
   syncSuggestCookie();
 
   initLiquidMetal($<HTMLCanvasElement>("#metal-canvas"), "flashbang");
-  $(".wordmark").classList.add("has-shader");
-  initHome(db);
+  const refreshHomeCatalog = initHome(db);
 
   const { openDialog } = setupDialog({
     closeButton: $("#modal-close"),
     modal: $("#settings-modal"),
     onFirstOpen: () =>
-      void initSettings(db, __ALLOW_UNSAFE_CUSTOM_SUGGEST_URLS__),
+      void initSettings(
+        db,
+        __ALLOW_UNSAFE_CUSTOM_SUGGEST_URLS__,
+        refreshHomeCatalog
+      ),
     openButton: $("#gear-btn"),
   });
 

--- a/src/ui/home/command.ts
+++ b/src/ui/home/command.ts
@@ -15,7 +15,12 @@ function customDomain(url: string): string {
   }
 }
 
-export function setupBangCommand(db: DB): HTMLInputElement {
+export interface BangCommandController {
+  input: HTMLInputElement;
+  refresh: () => Promise<void>;
+}
+
+export function setupBangCommand(db: DB): BangCommandController {
   const form = $<HTMLFormElement>("#bang-command-form");
   const input = $<HTMLInputElement>("#bang-command-input");
   const selectedBadge = $<HTMLButtonElement>("#bang-command-selected");
@@ -29,6 +34,7 @@ export function setupBangCommand(db: DB): HTMLInputElement {
   let optionElements: HTMLButtonElement[] = [];
   let selectedCommand: { marker: "!" | "@"; trigger: string } | null = null;
   let selected = -1;
+  let catalogVersion = 0;
 
   function closeResults(): void {
     results.classList.add("hidden");
@@ -204,11 +210,15 @@ export function setupBangCommand(db: DB): HTMLInputElement {
     if (loading) {
       return loading;
     }
-    loading = Promise.all([
+    const version = catalogVersion;
+    const request = Promise.all([
       loadBuiltinBangCatalog(),
       db.getAllCustomBangs().catch(() => []),
     ])
       .then(([catalog, custom]) => {
+        if (version !== catalogVersion) {
+          return;
+        }
         if (custom.length === 0) {
           entries = catalog.entries;
         } else {
@@ -232,14 +242,29 @@ export function setupBangCommand(db: DB): HTMLInputElement {
         count.textContent = `${entries.length.toLocaleString()} shortcuts`;
       })
       .catch(() => {
+        if (version !== catalogVersion) {
+          return;
+        }
         entries = [];
         count.textContent = "Bang index unavailable";
       })
       .finally(() => {
-        loading = null;
-        renderResults();
+        if (loading === request) {
+          loading = null;
+        }
+        if (version === catalogVersion) {
+          renderResults();
+        }
       });
-    return loading;
+    loading = request;
+    return request;
+  }
+
+  function refresh(): Promise<void> {
+    catalogVersion++;
+    entries = null;
+    loading = null;
+    return loadEntries();
   }
 
   input.addEventListener("focus", () => void loadEntries());
@@ -325,5 +350,5 @@ export function setupBangCommand(db: DB): HTMLInputElement {
   } else {
     setTimeout(() => void loadEntries(), 800);
   }
-  return input;
+  return { input, refresh };
 }

--- a/src/ui/home/index.ts
+++ b/src/ui/home/index.ts
@@ -3,8 +3,9 @@ import { setupAddressBarSheet } from "./address-bar-setup";
 import { setupBangCommand } from "./command";
 import { setupHomeShortcuts } from "./shortcuts";
 
-export function initHome(db: DB): void {
-  const input = setupBangCommand(db);
+export function initHome(db: DB): () => Promise<void> {
+  const { input, refresh } = setupBangCommand(db);
   setupHomeShortcuts(input);
   setupAddressBarSheet();
+  return refresh;
 }

--- a/src/ui/liquid-metal.ts
+++ b/src/ui/liquid-metal.ts
@@ -134,6 +134,17 @@ export function initLiquidMetal(
   canvas: HTMLCanvasElement,
   text: string
 ): LiquidMetalControls {
+  try {
+    return initLiquidMetalShader(canvas, text);
+  } catch {
+    return fallback(canvas);
+  }
+}
+
+function initLiquidMetalShader(
+  canvas: HTMLCanvasElement,
+  text: string
+): LiquidMetalControls {
   const maybeGl = canvas.getContext("webgl2", {
     alpha: true,
     premultipliedAlpha: false,
@@ -231,6 +242,8 @@ export function initLiquidMetal(
     rafId = requestAnimationFrame(render);
   }
 
+  canvas.closest(".wordmark")?.classList.add("has-shader");
+
   return {
     destroy() {
       destroyed = true;
@@ -276,6 +289,7 @@ export function initLiquidMetal(
 
 function fallback(canvas: HTMLCanvasElement): LiquidMetalControls {
   canvas.style.display = "none";
+  canvas.closest(".wordmark")?.classList.remove("has-shader");
   return {
     destroy() {
       // no-op when WebGL is unavailable

--- a/src/ui/settings/index.ts
+++ b/src/ui/settings/index.ts
@@ -19,7 +19,8 @@ const SETTINGS_KEYS = [
 
 export async function initSettings(
   db: DB,
-  allowUnsafeCustomSuggestUrls = false
+  allowUnsafeCustomSuggestUrls = false,
+  onCatalogChange?: () => void
 ): Promise<void> {
   const defaultInput = $<HTMLInputElement>("#default-bang");
   const importFile = $<HTMLInputElement>("#import-file");
@@ -92,6 +93,7 @@ export async function initSettings(
     (custom) => {
       state.custom = custom;
       syncCookie();
+      onCatalogChange?.();
     },
     writer.run
   );

--- a/tests/custom-trigger.test.ts
+++ b/tests/custom-trigger.test.ts
@@ -28,6 +28,8 @@ describe("custom trigger validation", () => {
       "foo!bar",
       "foo@bar",
       "foo+bar",
+      "foo,bar",
+      "foo:bar",
     ]) {
       expect(validateCustomTrigger(trigger)).not.toBeNull();
     }
@@ -45,7 +47,14 @@ describe("custom trigger validation", () => {
   });
 
   test("rejects reserved triggers case-insensitively", () => {
-    expect(validateCustomTrigger("settings")).toContain("reserved");
-    expect(validateCustomTrigger("SETTINGS")).toContain("reserved");
+    for (const trigger of [
+      "settings",
+      "SETTINGS",
+      "__proto__",
+      "constructor",
+      "prototype",
+    ]) {
+      expect(validateCustomTrigger(trigger)).toContain("reserved");
+    }
   });
 });

--- a/tests/frecency-serial.test.ts
+++ b/tests/frecency-serial.test.ts
@@ -10,9 +10,13 @@ describe("frecency compact serialization", () => {
   });
 
   test("round-trips compact key/count pairs", () => {
-    const serialized = serializeFrecencyCompact({ g: 10, ddg: 3 });
+    const counts = Object.create({ inherited: 99 }) as Record<string, number>;
+    counts.g = 10;
+    counts.ddg = 3;
+    const serialized = serializeFrecencyCompact(counts);
     const parsed = parseFrecencyCompact(serialized);
     expect(parsed).toEqual({ g: 10, ddg: 3 });
+    expect(serialized).not.toContain("inherited");
   });
 
   test("ignores malformed and non-positive entries during parse", () => {

--- a/tests/headers.test.ts
+++ b/tests/headers.test.ts
@@ -11,6 +11,8 @@ describe("server headers", () => {
     expect(SW_HEADERS["Referrer-Policy"]).toBe(
       "strict-origin-when-cross-origin"
     );
+    expect(SW_HEADERS["Strict-Transport-Security"]).toContain("max-age=");
+    expect(SW_HEADERS["Permissions-Policy"]).toContain("camera=()");
   });
 
   test("page headers compose caller script-src with core directives", () => {
@@ -21,5 +23,11 @@ describe("server headers", () => {
     expect(csp).toContain("frame-ancestors 'none'");
     expect(headers["X-Content-Type-Options"]).toBe("nosniff");
     expect(headers["X-Frame-Options"]).toBe("DENY");
+  });
+
+  test("page headers support hash-only inline script policy", () => {
+    const csp = pageHeaders("'sha256-example'")["Content-Security-Policy"];
+    expect(csp).toContain("script-src 'self' 'sha256-example'");
+    expect(csp).not.toContain("script-src 'self' 'unsafe-inline'");
   });
 });

--- a/tests/start-cache.test.ts
+++ b/tests/start-cache.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   acceptsBrotli,
   cacheControlForAsset,
+  extractInlineScriptHashes,
   staticAssetHeaders,
 } from "../scripts/start";
 
@@ -45,5 +46,16 @@ describe("production static caching", () => {
     expect(compressed.Vary).toBe("Accept-Encoding");
     expect(identity["Content-Encoding"]).toBeUndefined();
     expect(compressed["Content-Encoding"]).toBe("br");
+    expect(identity["Content-Security-Policy"]).not.toContain(
+      "script-src 'self' 'unsafe-inline'"
+    );
+  });
+
+  test("hashes only inline scripts for the production CSP", () => {
+    const hashes = extractInlineScriptHashes(
+      '<script>inline()</script><script type="module" src="/app.js"></script>'
+    );
+    expect(hashes).toHaveLength(1);
+    expect(hashes[0]).toMatch(/^'sha256-[A-Za-z0-9+/]+=*'$/);
   });
 });

--- a/tests/start-cache.test.ts
+++ b/tests/start-cache.test.ts
@@ -53,9 +53,12 @@ describe("production static caching", () => {
 
   test("hashes only inline scripts for the production CSP", () => {
     const hashes = extractInlineScriptHashes(
-      '<script>inline()</script><script type="module" src="/app.js"></script>'
+      '<script>inline()</script><SCRIPT nonce="test">upper()</SCRIPT>' +
+        '<script type="module" src="/app.js"></script>'
     );
-    expect(hashes).toHaveLength(1);
-    expect(hashes[0]).toMatch(/^'sha256-[A-Za-z0-9+/]+=*'$/);
+    expect(hashes).toHaveLength(2);
+    for (const hash of hashes) {
+      expect(hash).toMatch(/^'sha256-[A-Za-z0-9+/]+=*'$/);
+    }
   });
 });

--- a/tests/sw-idb.test.ts
+++ b/tests/sw-idb.test.ts
@@ -198,21 +198,6 @@ describe("sw/idb frecency", () => {
     expect(mod.getTopFrecencyRecord()).toEqual({ g: 5, ddg: 2 });
   });
 
-  test("migrates legacy JSON frecency format", async () => {
-    await seedDb({
-      settings: [
-        {
-          key: "frecency",
-          value: JSON.stringify({ c: { g: 2, yt: 1 }, t: Date.now() }),
-        },
-      ],
-    });
-
-    const mod = await loadSwIdb();
-    await mod.loadFrecency();
-    expect(mod.getTopFrecencyRecord()).toEqual({ g: 2, yt: 1 });
-  });
-
   test("settings invalidation preserves frecency and increments prior counts", async () => {
     await seedDb({
       settings: [{ key: "frecency", value: `${Date.now()}|` }],

--- a/tests/sw-runtime.test.ts
+++ b/tests/sw-runtime.test.ts
@@ -212,6 +212,8 @@ describe("sw runtime with real modules", () => {
     await handlers.activate?.(activateEvt.event);
     await Promise.all(activateEvt.waits);
     expect(claimCalls).toBe(1);
+    const swIdb = await import("../src/sw/idb");
+    expect(swIdb.getTopFrecencyRecord()).toEqual({ g: 2 });
     expect(cacheDeleteCalls).toEqual(["fb-old-cache", "flashbang-dev"]);
     expect(cacheDeleteCalls).not.toContain("other-cache");
   });


### PR DESCRIPTION
## Summary
- add CodeQL analysis for application and workflow code
- enforce secure production headers, hash-based CSP, safe trigger/frecency handling, and activation ordering
- preserve the wordmark fallback and refresh the homepage bang catalog after custom bang changes

## Validation
- bun test
- bun run typecheck
- bun run check
- bun run build