### PR TITLE
ci: harden tag-driven releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,22 +2,51 @@ name: Release
 
 on:
   push:
-    tags: ['v*']
+    tags: ['**']
 
 permissions:
   contents: read
 
 jobs:
-  release:
+  validate:
+    name: Validate release
     runs-on: ubuntu-24.04
     timeout-minutes: 15
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
+
+      - name: Validate release tag and package version
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$RELEASE_TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "::error::Release tag '$RELEASE_TAG' must match strict stable SemVer vX.Y.Z." >&2
+            exit 1
+          fi
+
+          tag_version="${RELEASE_TAG#v}"
+          package_version="$(bun -e 'const p = await Bun.file("package.json").json(); if (typeof p.version !== "string") { console.error("package.json version must be a string"); process.exit(1); } process.stdout.write(p.version);')"
+          if [ "$tag_version" != "$package_version" ]; then
+            echo "::error::Release tag version '$tag_version' does not match package.json version '$package_version'." >&2
+            exit 1
+          fi
+
+      - name: Verify release ancestry
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin +master:refs/remotes/origin/master
+          tagged_commit="$(git rev-parse 'HEAD^{commit}')"
+          if ! git merge-base --is-ancestor "$tagged_commit" refs/remotes/origin/master; then
+            echo "::error::Tagged commit '$tagged_commit' is not contained in origin/master." >&2
+            exit 1
+          fi
+
       - run: bun install --frozen-lockfile
       - run: bun run codegen -- --from-merged
       - run: bun run typecheck
@@ -25,14 +54,26 @@ jobs:
       - run: bun audit
       - run: bun test
       - run: bun run build
-      - name: Create or update GitHub Release
+
+  release:
+    name: Create GitHub Release
+    needs: validate
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - name: Create GitHub Release
         run: |
           set -euo pipefail
-          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
-            echo "Release $GITHUB_REF_NAME already exists; updating metadata."
-            gh release edit "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --latest
-          else
-            gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --generate-notes --latest
+          if ! gh release create "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --verify-tag \
+            --title "$GITHUB_REF_NAME" \
+            --generate-notes \
+            --latest; then
+            echo "::error::Failed to create GitHub Release for '$GITHUB_REF_NAME'." >&2
+            exit 1
           fi
         env:
           GH_TOKEN: ${{ github.token }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Each repository entry looks like:
 ```
 
 - The key is the trigger (e.g. `!mdn`)
-- `url` uses `{}` as the query placeholder for search bangs; it may omit `{}` for a fixed destination such as the repository's internal `settings` shortcut
+- `url` uses `{}` as the query placeholder for search bangs; the only supported fixed destination is the repository's internal `/settings` shortcut
 - `domain` is used for metadata display in the bang search UI
 
 After editing, run:
@@ -39,12 +39,12 @@ bun run codegen
 
 This fetches the current DuckDuckGo and Kagi sources, merges all sources, updates the committed `data/bangs.json`, and regenerates the ignored `src/generated/` artifacts. Commit both `data/custom-bangs.json` and `data/bangs.json`; do not commit `data/ddg.json`, `data/kagi.json`, or `src/generated/`.
 
-The repository custom-bang file supports simple `{}` templates and fixed-destination URLs. Regex capture templates and alternate snap targets are user-facing advanced settings and upstream Kagi metadata; see [DEVELOPMENT.md](DEVELOPMENT.md#advanced-bangs-and-snap-targets) before changing their parser or generated representation.
+The repository custom-bang file supports simple `{}` templates plus the special internal `/settings` destination. Regex capture templates and alternate snap targets are user-facing advanced settings and upstream Kagi metadata; see [DEVELOPMENT.md](DEVELOPMENT.md#advanced-bangs-and-snap-targets) before changing their parser or generated representation.
 
 ## Pull requests
 
 - Branch from `master`
-- Run `bun run typecheck`, `bun run check`, `bun test`, and `bun run build` before submitting
+- Run `bun run typecheck`, `bun run check`, `bun audit`, `bun test`, and `bun run build` before submitting
 - Run `bun run test:e2e` for UI, Service Worker, settings, or other browser-visible changes
 - Use [conventional commits](https://www.conventionalcommits.org/), including the repository's common `feat:`, `fix:`, `perf:`, `docs:`, `test:`, `refactor:`, and `chore:` types
 - Keep PRs focused — one concern per PR
@@ -53,15 +53,16 @@ The repository custom-bang file supports simple `{}` templates and fixed-destina
 
 We use **GitHub Releases** as the canonical place for release notes and version history.
 
-- Version tags use `vX.Y.Z` (for example `v1.4.1`)
-- Pushing a release tag triggers `.github/workflows/release.yaml`
-- The workflow validates the release, creates or updates its GitHub Release, health-checks a container, and publishes `linux/amd64` and `linux/arm64` images to GHCR
+- Version tags must use strict stable SemVer `vX.Y.Z` (for example `v1.5.0`) and match the version in `package.json`
+- Maintainers push the version commit to `master`, wait for protected-branch CI, then create and push an annotated tag; they do not create the GitHub Release manually
+- The tag-triggered workflow verifies that the tagged commit is contained in `origin/master`, runs its validation gates without repeating Playwright E2E, and creates the GitHub Release with generated notes
+- After release creation, the workflow health-checks a container and publishes `linux/amd64` and `linux/arm64` images to GHCR with the version and `latest` tags
 
-For the full maintainer release procedure (version bump, notes, tag, and workflow verification), see [DEVELOPMENT.md](DEVELOPMENT.md#releasing).
+For the full maintainer release procedure (version bump, annotated tag, and workflow verification), see [DEVELOPMENT.md](DEVELOPMENT.md#releasing).
 
 ## Tests
 
-All tests live in `tests/`. Run the unit and performance suite with:
+All tests live in `tests/`. Run the unit, integration, performance, and docs suite with:
 
 ```sh
 bun test
@@ -82,6 +83,7 @@ bunx playwright install
 Add tests for new logic and user-facing behavior. Look at existing tests for patterns:
 
 - `tests/redirect.test.ts` — redirect, capture bang, and snap routing logic
+- `tests/bang-catalog.test.ts` — bounded bang-catalog search and normalization
 - `tests/suggest.test.ts` — suggestions, providers, and cookie parsing
 - `tests/capture-template.test.ts` and `tests/snap-target.test.ts` — advanced custom-bang validation
 - `tests/codegen-roundtrip.test.ts` — generated regular, capture, and snap lookups

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- [Bun](https://bun.sh) (runtime and bundler)
+- [Bun](https://bun.sh) 1.3.14 (runtime, package manager, and bundler; the version is pinned in `package.json`, CI, and Docker)
 - [Git](https://git-scm.com)
 
 Playwright browsers are required for end-to-end tests (`bunx playwright install`). Maintainers also need the [GitHub CLI](https://cli.github.com) for releases and Docker for image/health-check work.
@@ -14,14 +14,15 @@ bun install        # install dependencies
 bun run check      # format + lint check (fails on issues)
 bun run fix        # auto-fix format + lint issues
 bun run codegen    # fetch DDG/Kagi sources, merge, and generate bang maps
-bun run build      # bundle, minify + pre-compress with Brotli (auto-runs codegen --from-merged if generated bang files are missing)
+bun run build      # install locked dependencies, then bundle, minify + pre-compress with Brotli (auto-runs codegen --from-merged if generated bang files are missing)
 bun run dev        # bundle + dev server with file watching & live reload (auto-runs codegen if needed)
 bun run start      # serve pre-built dist/ (run `bun run build` first)
 bun run typecheck  # type-check with tsc (no emit)
 bun run profile    # run performance profile benchmarks (auto-runs codegen --from-merged if generated bang files are missing)
 bun run profile:quick  # run a shorter profiling pass
 bun run profile:cpu   # write Bun CPU profiles under profiles/
-bun test           # run tests
+bun audit          # audit dependencies for known vulnerabilities
+bun test           # run unit, integration, performance, and docs tests
 bun run test:e2e   # run Playwright end-to-end tests (build + browser run)
 bun run clean      # remove dist/
 ```
@@ -147,14 +148,15 @@ Every tracked file must appear explicitly or match a glob in this tree. `tests/d
 ## Tests
 
 ```sh
-bun test           # run all tests
+bun test           # run unit, integration, performance, and docs tests
 bun run test:e2e   # run end-to-end tests (build + Playwright)
 ```
 
-Unit and performance tests:
+Unit, integration, performance, and docs tests:
 
 - `tests/redirect.test.ts` — Bang/snap parsing, routing logic, and URL encoding
 - `tests/redirect-perf.test.ts` — Redirect performance benchmarks
+- `tests/bang-catalog.test.ts` — Bounded UI bang-catalog search and normalization
 - `tests/capture-template.test.ts` — Capture template parsing and regex safety
 - `tests/snap-target.test.ts` — Alternate snap target validation
 - `tests/suggest.test.ts` — Cookie parsing, bang/snap suggestions, and provider proxying
@@ -222,8 +224,8 @@ On **self-hosted** (Docker/Railway via `start.ts`), the Bun server sets headers 
 `bun run build` bundles the app:
 
 1. **Bundle UI + bench** — Bun bundles `src/ui/app.ts` (with code splitting) to `dist/app.js` plus small chunks, and bundles `src/ui/bench/index.ts` to `dist/bench.js`
-2. **Bundle Service Worker** — Bun bundles `src/sw/sw.ts` (including `bangs-min.js`) into `dist/sw.js`; hashes of the UI outputs determine the injected cache version and extra precache assets
-3. **Generate CSS** — UnoCSS scans `src/ui/**/*.ts` and HTML files, emitting atomic utility classes
+2. **Bundle Service Worker** — Bun bundles `src/sw/sw.ts` (including `bangs-min.js`) into `dist/sw.js`; hashes of the precached assets and a preliminary Service Worker bundle determine the injected cache version, while small UI chunks become extra precache assets
+3. **Generate CSS** — UnoCSS scans `src/ui/**/*.ts`, `src/ui/home/index.html`, and `src/ui/bench/index.html`, emitting atomic utility classes
 4. **Inline & minify HTML** — CSS is inlined into `<style>`, HTML is minified with `@minify-html/node`
 5. **Generate static-host headers** — Writes `dist/_headers` with shared security headers, per-page inline-script hashes, the stricter Service Worker CSP, and the OpenSearch content type
 6. **Pre-compress** — Eligible text assets are compressed with Brotli (max quality) and written as `.br` files alongside the originals. The production server serves these automatically when the client supports it, falling back to uncompressed
@@ -295,19 +297,30 @@ Static assets are served with Brotli pre-compression when the client supports it
 
 ## CI
 
-A CI workflow (`.github/workflows/ci.yaml`) runs on every push and pull request to `master`. Its main job runs codegen (`--from-merged`), typecheck, lint/format checks, tests, and a full build with no external bang-source fetching. A separate matrix builds the app and runs the Playwright suite in Chromium, Firefox, and WebKit.
+A CI workflow (`.github/workflows/ci.yaml`) runs on every push to `master` and every pull request targeting `master`. Its main job runs codegen (`--from-merged`), typecheck, lint/format checks, `bun audit`, tests, and a full build with no external bang-source fetching. A separate matrix builds the app and runs the Playwright projects in Chromium, Firefox, and WebKit; the WebKit project intentionally selects a supported subset of scenarios. On pull requests and manual runs, a Docker job also builds and health-checks the image when Docker-relevant files changed.
 
-A daily cron workflow (`.github/workflows/update-bangs.yaml`) fetches fresh bang sources from DDG and Kagi, merges them, and commits the updated `data/bangs.json` when there are changes.
+A daily cron workflow (`.github/workflows/update-bangs.yaml`) fetches fresh bang sources from DDG and Kagi and verifies the merged data when it changes. It commits `data/bangs.json` to the `automation/update-bangs` branch, opens or updates a pull request targeting `master`, and dispatches CI for that branch.
 
 ## Releasing
 
 1. Update `version` in `package.json`
-2. Run `bun run typecheck`, `bun run check`, `bun test`, `bun run build`, and the relevant Playwright tests
-3. Commit and push: `chore: bump version to X.Y.Z`
-4. Write GitHub release notes following the previous release's structure, including a `vOLD...vNEW` compare link
-5. Create the tag and release: `gh release create vX.Y.Z --target master --title vX.Y.Z --notes-file <path> --latest`
+2. Run `bun run typecheck`, `bun run check`, `bun audit`, `bun test`, and `bun run build`
+3. Commit and push the version bump so the commit is on `origin/master`:
 
-The release workflow (`.github/workflows/release.yaml`) handles the rest:
-runs codegen (`--from-merged`), typecheck, lint/format checks, tests, and build, then creates or updates the GitHub Release without replacing existing custom notes.
+```sh
+git add package.json
+git commit -m "chore: bump version to X.Y.Z"
+git push origin master
+```
 
-Before publishing, the workflow builds a local image, runs it, and requires Docker's built-in container health status to become `healthy`. It then pushes `linux/amd64` and `linux/arm64` images to `ghcr.io/<owner>/flashbang` with both the release version and `latest` tags.
+4. Wait for the protected-branch CI checks, including Playwright E2E, to pass for that commit
+5. Create and push an annotated tag from that commit:
+
+```sh
+git tag -a vX.Y.Z -m "vX.Y.Z"
+git push origin vX.Y.Z
+```
+
+Do not create the GitHub Release manually. The tag-triggered release workflow (`.github/workflows/release.yaml`) accepts only strict stable `vX.Y.Z` tags, requires the tag version to match `package.json`, and verifies that the tagged commit is contained in `origin/master`. It then runs codegen (`--from-merged`), typecheck, lint/format checks, `bun audit`, the test suite, and the build. It does not rerun Playwright because protected-branch CI already covers E2E.
+
+After validation succeeds, the workflow creates the GitHub Release with generated notes. It then builds and health-checks a local image before publishing `linux/amd64` and `linux/arm64` images to `ghcr.io/<owner>/flashbang` with both the release version and `latest` tags.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "flashbang",
   "description": "The sub-1ms local first duck-duck-go style bang redirects",
   "private": true,
-  "version": "1.5.0",
+  "version": "1.5.1",
   "type": "module",
   "packageManager": "bun@1.3.14",
   "scripts": {


### PR DESCRIPTION
## Summary

- make the tag-triggered workflow validate strict SemVer, package version, and master ancestry before creating a GitHub Release
- preserve generated release notes, Docker health checks, multi-architecture GHCR publishing, and least-privilege permissions
- correct development and contribution guidance, including the PR-based bang updater and annotated-tag release process
- bump the package version to 1.5.1

## Testing

- `bun run codegen -- --from-merged`
- `bun run typecheck`
- `bun run check`
- `bun audit`
- `bun test`
- `bun run build`
- release workflow YAML parse, SemVer cases, package-version match, and master-ancestry check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Releases now automatically generate release notes when published.
  * Release tags are validated against the application version and protected branch before publication.
* **Bug Fixes**
  * Invalid, mismatched, or unverified release tags can no longer create releases.
  * Releases are blocked when quality checks, tests, builds, or security audits fail.
* **Documentation**
  * Updated contribution, development, testing, CI, and release guidance.
  * Clarified command usage, supported version requirements, and release procedures.
* **Chores**
  * Updated the application version to 1.5.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->