### PR TITLE
fix(ci): create new bang update pull requests

### DIFF
--- a/.github/workflows/update-bangs.yaml
+++ b/.github/workflows/update-bangs.yaml
@@ -74,8 +74,15 @@ jobs:
           gh auth setup-git
           git push --force-with-lease origin "HEAD:refs/heads/$branch"
 
-          if gh pr view "$branch" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            gh pr edit "$branch" --repo "$GITHUB_REPOSITORY" \
+          pr="$(gh pr list --repo "$GITHUB_REPOSITORY" \
+            --base master \
+            --head "$branch" \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')"
+
+          if [ -n "$pr" ]; then
+            gh pr edit "$pr" --repo "$GITHUB_REPOSITORY" \
               --base master \
               --title "chore: update bangs" \
               --body "Automated daily update of the merged DuckDuckGo and Kagi bang data."


### PR DESCRIPTION
## Summary
- only reuse an existing open bang-update PR
- create a fresh PR after the previous automation PR has been merged

## Verification
- `bun run check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated update handling to reliably detect existing pull requests.
  * Existing update pull requests are now refreshed instead of duplicated.
  * New pull requests are created automatically when no matching request is found.
  * This provides more consistent and streamlined delivery of automated updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->