### PR TITLE
chore: release v1.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "flashbang",
   "description": "The sub-1ms local first duck-duck-go style bang redirects",
   "private": true,
-  "version": "1.5.1",
+  "version": "1.5.2",
   "type": "module",
   "packageManager": "bun@1.3.14",
   "scripts": {


### PR DESCRIPTION
## Summary

- release redirect, default-bang, and offline app-shell fixes merged since v1.5.1
- include refreshed bang data and repaired bang-update pull request automation
- include packed bang metadata for a smaller, faster-loading UI catalog
- bump the package version to 1.5.2

## Verification

- `bun run codegen -- --from-merged`
- `bun run typecheck`
- `bun run check`
- `bun audit`
- `bun test` (371 passed)
- `bun run build`