### PR TITLE
fix(sw): defer app precaching from installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "flashbang",
   "description": "The sub-1ms local first duck-duck-go style bang redirects",
   "private": true,
-  "version": "1.5.2",
+  "version": "1.5.3",
   "type": "module",
   "packageManager": "bun@1.3.14",
   "scripts": {

--- a/src/sw/sw.ts
+++ b/src/sw/sw.ts
@@ -25,7 +25,7 @@ const LEGACY_CACHE_NAMES = new Set(["flashbang-dev"]);
 const CACHE_NAME = __CACHE_VERSION__.startsWith(CACHE_PREFIX)
   ? __CACHE_VERSION__
   : `${CACHE_PREFIX}${__CACHE_VERSION__}`;
-const REQUIRED_ASSETS = [
+const APP_ASSETS = [
   "/home",
   "/app.js",
   "/icon.svg",
@@ -33,9 +33,9 @@ const REQUIRED_ASSETS = [
   ...__REQUIRED_APP_ASSETS__,
 ];
 
-const OPTIONAL_ASSETS = ["/bench", "/bench.js"];
+const DEFERRED_ASSETS = [...APP_ASSETS, "/bench", "/bench.js"];
 const PRECACHE_CONCURRENCY = 4;
-let optionalPrecachePromise: Promise<void> | null = null;
+let deferredPrecachePromise: Promise<void> | null = null;
 let benchmarkClientId: string | null = null;
 const RESOLVED_PROMISE: Promise<void> = Promise.resolve();
 const swallowError = () => {
@@ -87,14 +87,14 @@ async function deleteOldCaches(cacheName: string): Promise<void> {
   );
 }
 
-function ensureOptionalPrecache(): Promise<void> {
-  if (optionalPrecachePromise) {
-    return optionalPrecachePromise;
+function ensureDeferredPrecache(): Promise<void> {
+  if (deferredPrecachePromise) {
+    return deferredPrecachePromise;
   }
-  optionalPrecachePromise = precacheAssets(CACHE_NAME, OPTIONAL_ASSETS).catch(
+  deferredPrecachePromise = precacheAssets(CACHE_NAME, DEFERRED_ASSETS).catch(
     swallowError
   );
-  return optionalPrecachePromise;
+  return deferredPrecachePromise;
 }
 
 function findQueryValueStart(raw: string): number {
@@ -154,9 +154,7 @@ function queueBangSideEffects(e: FetchEvent, trigger: string): void {
 }
 
 self.addEventListener("install", (e: ExtendableEvent) => {
-  e.waitUntil(
-    precacheAssets(CACHE_NAME, REQUIRED_ASSETS).then(() => self.skipWaiting())
-  );
+  e.waitUntil(self.skipWaiting());
 });
 
 self.addEventListener("activate", (e: ExtendableEvent) => {
@@ -247,9 +245,9 @@ self.addEventListener("fetch", (e: FetchEvent) => {
     }
   }
 
-  // Redirect requests should not compete with optional UI asset warmup.
-  if (!optionalPrecachePromise) {
-    e.waitUntil(ensureOptionalPrecache());
+  // Redirect requests should not install or compete with UI assets.
+  if (!deferredPrecachePromise) {
+    e.waitUntil(ensureDeferredPrecache());
   }
 
   if (raw.endsWith("/bench")) {

--- a/tests/sw-runtime.test.ts
+++ b/tests/sw-runtime.test.ts
@@ -204,7 +204,7 @@ afterEach(async () => {
 });
 
 describe("sw runtime with real modules", () => {
-  test("lifecycle deletes stale Flashbang caches and preserves unrelated caches", async () => {
+  test("lifecycle defers app precaching and preserves unrelated caches", async () => {
     await loadSwRuntime(["/chunk-catalog123.js"]);
     expect(typeof handlers.install).toBe("function");
     expect(typeof handlers.activate).toBe("function");
@@ -213,13 +213,7 @@ describe("sw runtime with real modules", () => {
     await handlers.install?.(installEvt.event);
     await Promise.all(installEvt.waits);
     expect(skipWaitingCalls).toBe(1);
-    expect(fetchCalls.toSorted()).toEqual([
-      "/app.js",
-      "/chunk-catalog123.js",
-      "/home",
-      "/icon.svg",
-      "/manifest.json",
-    ]);
+    expect(fetchCalls).toEqual([]);
 
     const activateEvt = createExtendableEvent();
     await handlers.activate?.(activateEvt.event);
@@ -229,9 +223,23 @@ describe("sw runtime with real modules", () => {
     expect(swIdb.getTopFrecencyRecord()).toEqual({ g: 2 });
     expect(cacheDeleteCalls).toEqual(["fb-old-cache", "flashbang-dev"]);
     expect(cacheDeleteCalls).not.toContain("other-cache");
+
+    const fetchEvt = createFetchEvent("https://flashbang.local/home");
+    await handlers.fetch?.(fetchEvt.event);
+    await Promise.all(fetchEvt.waits);
+    await fetchEvt.response();
+    expect([...new Set(fetchCalls)].toSorted()).toEqual([
+      "/app.js",
+      "/bench",
+      "/bench.js",
+      "/chunk-catalog123.js",
+      "/home",
+      "/icon.svg",
+      "/manifest.json",
+    ]);
   });
 
-  test("does not activate when a required app asset cannot be cached", async () => {
+  test("does not block installation when deferred app precaching fails", async () => {
     await loadSwRuntime(["/chunk-catalog123.js"]);
     fetchImpl = (input) => {
       const raw =
@@ -244,9 +252,15 @@ describe("sw runtime with real modules", () => {
 
     const installEvt = createExtendableEvent();
     await handlers.install?.(installEvt.event);
-    await expect(Promise.all(installEvt.waits)).rejects.toThrow("offline");
-    expect(skipWaitingCalls).toBe(0);
-    expect(cacheDeleteCalls).toEqual([]);
+    await Promise.all(installEvt.waits);
+    expect(skipWaitingCalls).toBe(1);
+    expect(fetchCalls).toEqual([]);
+
+    const fetchEvt = createFetchEvent("https://flashbang.local/home");
+    await handlers.fetch?.(fetchEvt.event);
+    await Promise.all(fetchEvt.waits);
+    await fetchEvt.response();
+    expect(fetchCalls).toContain("/chunk-catalog123.js");
   });
 
   test("message redirect and invalidate paths work end-to-end", async () => {
@@ -286,8 +300,8 @@ describe("sw runtime with real modules", () => {
     );
   });
 
-  test("fetch q= path responds with redirect without optional precaching", async () => {
-    await loadSwRuntime();
+  test("fetch q= path redirects without deferred app precaching", async () => {
+    await loadSwRuntime(["/chunk-catalog123.js"]);
     expect(typeof handlers.fetch).toBe("function");
 
     for (const url of [
@@ -302,6 +316,7 @@ describe("sw runtime with real modules", () => {
       expect(location).toContain("google.com");
       expect(new URL(location!).searchParams.get("q")).toBe("hello");
       expect(fetchEvt.waits).toHaveLength(0);
+      expect(fetchCalls).toEqual([]);
     }
   });
 


### PR DESCRIPTION
## Summary

- keep service-worker installation focused on activating redirect handling instead of downloading the UI and catalog
- defer complete app, catalog, and benchmark precaching until the first non-redirect request
- ensure redirect requests neither start nor wait for app asset warmup
- add lifecycle regression coverage for installation, deferred warmup failures, and redirect priority
- bump the package version to 1.5.3

## Verification

- `bun run codegen -- --from-merged`
- `bun run typecheck`
- `bun run check`
- `bun audit`
- `bun test` (371 passed)
- `bun run build`
- `git diff --check`