### PR TITLE
fix(security): run Docker runtime as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,8 @@ COPY --from=builder /app/src/shared/suggest-cookie.ts src/shared/suggest-cookie.
 COPY --from=builder /app/src/shared/template.ts src/shared/template.ts
 COPY --from=builder /app/src/generated/bangs-trie.js src/generated/bangs-trie.js
 
+USER bun
+
 ENV PORT=3000
 EXPOSE 3000
 HEALTHCHECK --interval=2s --timeout=2s --start-period=2s --retries=5 CMD bun -e "fetch('http://127.0.0.1:' + process.env.PORT + '/health').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"


### PR DESCRIPTION
## Summary

- run the production Bun server as the image-provided unprivileged `bun` user
- keep runtime application files root-owned and read-only to the process

## Verification

- `bun run check`
- `bun test` (371 tests)
- `docker build --tag flashbang:docker-non-root .`
- verified image user is `bun` / UID 1000
- verified container reaches `healthy` and `/health` returns `200 ok`