### PR TITLE
perf(sw): load bang data from binary artifact

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -78,11 +78,13 @@ flashbang/
 │   │   ├── template.ts        # Bang URL template expansion
 │   │   └── trie.ts            # Radix trie lookup
 │   ├── generated/             # Output of codegen (gitignored, generated from data/bangs.json)
-│   │   ├── bangs-min.js       # trigger→URL map for Service Worker
+│   │   ├── bangs.bin          # packed trigger→URL data for Service Worker
+│   │   ├── bangs-sparse.js    # advanced bang and snap override lookups
 │   │   ├── bangs-meta.js      # trigger→{name, domain} for UI
 │   │   ├── bangs-trie.js      # radix trie for prefix-matched bang suggestions
 │   │   └── *.d.ts             # TypeScript declarations for each generated .js file
 │   ├── sw/
+│   │   ├── bang-data.ts       # Binary bang decoder and regular lookup
 │   │   ├── sw.ts              # Service Worker lifecycle & fetch handler
 │   │   ├── redirect.ts        # Bang/snap parsing & redirect logic (zero-copy raw + decoded paths)
 │   │   ├── idb.ts             # IndexedDB access, settings cache & in-memory frecency
@@ -124,6 +126,7 @@ flashbang/
 │   ├── e2e/
 │   │   └── flashbang.e2e.ts  # Playwright browser scenarios
 │   ├── helpers/
+│   │   ├── bang-data.ts       # Generated binary initialization for tests
 │   │   └── fake-indexeddb.ts # IndexedDB test double
 │   └── *.test.ts             # Unit, integration, performance, and docs checks
 ├── .dockerignore             # Files excluded from Docker build context
@@ -186,12 +189,13 @@ bunx playwright install
 
 ## Bang codegen
 
-`bun run codegen` fetches bang sources and generates the JavaScript bang maps that `build` and `dev` depend on:
+`bun run codegen` fetches bang sources and generates the bang artifacts that `build` and `dev` depend on:
 
 1. **Fetch sources** — Downloads bang definitions from DuckDuckGo (`bang.js`) and Kagi (`bangs.json`) into `data/`
 2. **Merge + validate** — Parses DDG, Kagi, and custom sources. Merges by trigger (deduplicates), validates URLs, and saves the merged result to `data/bangs.json`
-3. **Generate** — Produces three JS files in `src/generated/` from the merged data:
-   - `bangs-min.js` — packed regular lookup plus sparse capture and snap overrides for the Service Worker
+3. **Generate** — Produces the following artifacts in `src/generated/` from the merged data:
+   - `bangs.bin` — packed regular bang lookup data for the Service Worker
+   - `bangs-sparse.js` — sparse capture and snap override lookups for the Service Worker
    - `bangs-meta.js` — trigger→{name, domain} for the UI
    - `bangs-trie.js` — radix trie for prefix-matched bang suggestions
    - plus matching `*.d.ts` declaration files for all generated modules
@@ -224,7 +228,7 @@ On **self-hosted** (Docker/Railway via `start.ts`), the Bun server sets headers 
 `bun run build` bundles the app:
 
 1. **Bundle UI + bench** — Bun bundles `src/ui/app.ts` (with code splitting) to `dist/app.js` plus lazy chunks, and bundles `src/ui/bench/index.ts` to `dist/bench.js`. Every app chunk is marked as a required offline dependency regardless of size; benchmark assets remain optional.
-2. **Bundle Service Worker** — Bun bundles `src/sw/sw.ts` (including `bangs-min.js`) into `dist/sw.js`; hashes of the precached assets and a preliminary Service Worker bundle determine the injected cache version. The worker precaches the complete required app shell before activating, then removes old versioned caches.
+2. **Bundle Service Worker** — Bun bundles `src/sw/sw.ts` and the sparse generated lookups into `dist/sw.js`, then copies `bangs.bin` to a content-hashed production path. The path is injected into the worker and HTML preload tags, and receives immutable cache headers. Hashes of the binary, precached assets, and a preliminary Service Worker bundle determine the injected cache version. The worker caches the binary before activating, then removes old versioned caches.
 3. **Generate CSS** — UnoCSS scans `src/ui/**/*.ts`, `src/ui/home/index.html`, and `src/ui/bench/index.html`, emitting atomic utility classes
 4. **Inline & minify HTML** — CSS is inlined into `<style>`, HTML is minified with `@minify-html/node`
 5. **Generate static-host headers** — Writes `dist/_headers` with shared security headers, per-page inline-script hashes, the stricter Service Worker CSP, and the OpenSearch content type
@@ -261,7 +265,7 @@ The in-memory state (`frecencyCounts` plus `topFrecency` in `idb.ts`) is loaded 
 
 `bun run dev` runs the dev server with `bun --hot` for soft module reloading:
 
-- **Codegen guard** — If `src/generated/bangs-min.js` is missing, automatically runs `bun run codegen` before the first build
+- **Codegen guard** — If a required artifact under `src/generated/` is missing, automatically runs `bun run codegen` before the first build
 - **Inline builds** — Uses `Bun.build()` API directly instead of shelling out to build scripts
 - **File watching** — Watches `src/` recursively via `fs.watch` with 200ms debounce. Any source change triggers a full rebuild
 - **Live reload** — SSE endpoint at `/__dev/events` pushes reload events to the browser. A small script is injected into HTML responses that unregisters the Service Worker, clears all caches, and reloads the page on each rebuild

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "flashbang",
   "description": "The sub-1ms local first duck-duck-go style bang redirects",
   "private": true,
-  "version": "1.5.3",
+  "version": "1.5.4",
   "type": "module",
   "packageManager": "bun@1.3.14",
   "scripts": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -42,7 +42,7 @@ export default defineConfig({
     {
       name: "webkit",
       use: { ...devices["Desktop Safari"] },
-      grep: /suggest endpoint|Firefox locks|opensearch endpoint|suggestions include custom|homepage bang finder|compact address-bar setup|default provider labels|settings persist suggest provider none|settings persist custom bang creation|settings reject invalid/,
+      grep: /suggest endpoint|Firefox locks|opensearch endpoint|suggestions include custom|homepage bang finder|compact address-bar setup|default provider labels|settings persist suggest provider none|settings persist custom bang creation|settings reject invalid|warm redirect/,
     },
   ],
   webServer: {

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -40,9 +40,11 @@ export function createCacheVersion(
 }
 
 export function precacheFileInputs(
-  requiredAppAssets: readonly string[]
+  requiredAppAssets: readonly string[],
+  bangDataAsset = "/bangs.bin"
 ): ReadonlyArray<readonly [assetPath: string, filePath: string]> {
   return [
+    [bangDataAsset, `${DIST_DIR}${bangDataAsset}`],
     ["/home", `${DIST_DIR}/home.html`],
     ["/bench", `${DIST_DIR}/bench.html`],
     ["/bench.js", `${DIST_DIR}/bench.js`],
@@ -71,7 +73,8 @@ export function requiredAppAssetPaths(
 async function bundleServiceWorker(
   naming: string,
   cacheVersion: string,
-  requiredAppAssets: readonly string[]
+  requiredAppAssets: readonly string[],
+  bangDataAsset: string
 ): Promise<void> {
   const result = await Bun.build({
     entrypoints: ["src/sw/sw.ts"],
@@ -81,6 +84,7 @@ async function bundleServiceWorker(
     target: "browser",
     format: "esm",
     define: {
+      __BANG_DATA_ASSET__: JSON.stringify(bangDataAsset),
       __CACHE_VERSION__: JSON.stringify(cacheVersion),
       __REQUIRED_APP_ASSETS__: JSON.stringify(requiredAppAssets),
       __IS_DEV__: JSON.stringify(false),
@@ -101,6 +105,13 @@ async function main(): Promise<void> {
   // Start from a clean dist to avoid stale artifacts (e.g. orphaned .br chunks).
   await rm(DIST_DIR, { recursive: true, force: true });
   await mkdir(DIST_DIR, { recursive: true });
+  const bangDataBytes = await Bun.file("src/generated/bangs.bin").bytes();
+  const bangDataHash = createHash("sha256")
+    .update(bangDataBytes)
+    .digest("hex")
+    .slice(0, 12);
+  const bangDataAsset = `/bangs-${bangDataHash}.bin`;
+  await Bun.write(`${DIST_DIR}${bangDataAsset}`, bangDataBytes);
 
   console.log("=== Bundle app + bench (to discover chunks) ===");
   const { appOutputs } = await bundleUI(allowUnsafeCustomSuggestUrls);
@@ -114,7 +125,7 @@ async function main(): Promise<void> {
   await generateCSS();
 
   console.log("=== Inline CSS + minify HTML ===");
-  await assembleUIAssets(allowUnsafeCustomSuggestUrls);
+  await assembleUIAssets(allowUnsafeCustomSuggestUrls, bangDataAsset);
   await rm(`${DIST_DIR}/styles.css`);
 
   console.log("=== Compute service worker cache version ===");
@@ -123,10 +134,11 @@ async function main(): Promise<void> {
   await bundleServiceWorker(
     "sw-cache-input.js",
     "fb-cache-version-input",
-    requiredAppAssets
+    requiredAppAssets,
+    bangDataAsset
   );
   const cacheInputs: CacheVersionInput[] = await Promise.all(
-    precacheFileInputs(requiredAppAssets).map(
+    precacheFileInputs(requiredAppAssets, bangDataAsset).map(
       async ([assetPath, filePath]) => ({
         path: assetPath,
         bytes: await Bun.file(filePath).bytes(),
@@ -142,7 +154,12 @@ async function main(): Promise<void> {
   console.log(`Cache version: ${cacheVersion}`);
 
   console.log("=== Bundle service worker ===");
-  await bundleServiceWorker("sw.js", cacheVersion, requiredAppAssets);
+  await bundleServiceWorker(
+    "sw.js",
+    cacheVersion,
+    requiredAppAssets,
+    bangDataAsset
+  );
 
   console.log("=== Generate _headers with CSP ===");
   function extractScriptHashes(html: string): string[] {
@@ -196,6 +213,9 @@ async function main(): Promise<void> {
       "/sw.js",
       `  ${swCspHeader}`,
       "",
+      bangDataAsset,
+      "  Cache-Control: public, max-age=31536000, immutable",
+      "",
       "/opensearch.xml",
       "  Content-Type: application/opensearchdescription+xml",
       "",
@@ -203,7 +223,7 @@ async function main(): Promise<void> {
   );
 
   console.log("=== Pre-compress static assets ===");
-  for (const file of new Bun.Glob("*.{html,js,svg,json,txt}").scanSync(
+  for (const file of new Bun.Glob("*.{bin,html,js,svg,json,txt}").scanSync(
     DIST_DIR
   )) {
     const content = await Bun.file(`${DIST_DIR}/${file}`).bytes();

--- a/scripts/codegen.ts
+++ b/scripts/codegen.ts
@@ -354,6 +354,32 @@ function dedupeStrings(values: readonly string[]): {
   return { ids, unique };
 }
 
+function orderStringsByLength(values: readonly string[]): {
+  ordered: string[];
+  remap: number[];
+} {
+  const indexes = values.map((_, index) => index);
+  indexes.sort((a, b) => {
+    const lengthDifference = values[a].length - values[b].length;
+    if (lengthDifference !== 0) {
+      return lengthDifference;
+    }
+    if (values[a] < values[b]) {
+      return -1;
+    }
+    return values[a] > values[b] ? 1 : 0;
+  });
+
+  const ordered = new Array<string>(values.length);
+  const remap = new Array<number>(values.length);
+  for (let id = 0; id < indexes.length; id++) {
+    const oldId = indexes[id];
+    ordered[id] = values[oldId];
+    remap[oldId] = id;
+  }
+  return { ordered, remap };
+}
+
 function nextPow2(n: number): number {
   let p = 1;
   while (p < n) {
@@ -399,14 +425,14 @@ function packBangData(bangs: Bang[]): PackedBangData {
     rawSuffixes[i] = suffix;
   }
 
-  const { ids: prefixIds, unique: uniquePrefixes } = dedupeStrings(prefixes);
+  let { ids: prefixIds, unique: uniquePrefixes } = dedupeStrings(prefixes);
   if (uniquePrefixes.length > 0xffff) {
     throw new Error(
       `Binary bang format requires <= 65535 unique prefixes, got ${uniquePrefixes.length}`
     );
   }
 
-  const uniqueSuffixes: string[] = [];
+  let uniqueSuffixes: string[] = [];
   const suffixIdsPlusOne = new Array<number>(entryCount);
   const suffixMap = new Map<string, number>();
   for (let i = 0; i < entryCount; i++) {
@@ -429,6 +455,19 @@ function packBangData(bangs: Bang[]): PackedBangData {
     uniqueSuffixes.push(suffix);
     suffixMap.set(suffix, id);
     suffixIdsPlusOne[i] = id + 1;
+  }
+
+  const orderedPrefixes = orderStringsByLength(uniquePrefixes);
+  uniquePrefixes = orderedPrefixes.ordered;
+  prefixIds = prefixIds.map((id) => orderedPrefixes.remap[id]);
+
+  const orderedSuffixes = orderStringsByLength(uniqueSuffixes);
+  uniqueSuffixes = orderedSuffixes.ordered;
+  for (let i = 0; i < suffixIdsPlusOne.length; i++) {
+    const id = suffixIdsPlusOne[i];
+    if (id !== 0) {
+      suffixIdsPlusOne[i] = orderedSuffixes.remap[id - 1] + 1;
+    }
   }
 
   const triggerBlob = packBlob(triggers);

--- a/scripts/codegen.ts
+++ b/scripts/codegen.ts
@@ -1,10 +1,5 @@
 import { Buffer } from "node:buffer";
 import { mkdir } from "node:fs/promises";
-import {
-  type BrotliOptions,
-  brotliCompress,
-  constants as zlibConstants,
-} from "node:zlib";
 import { $ } from "bun";
 import {
   CAPTURE_ENCODE_PERCENT,
@@ -53,7 +48,8 @@ interface RawKagiEntry {
 }
 
 export const GENERATED_BANG_DATA_FILES = [
-  "src/generated/bangs-min.js",
+  "src/generated/bangs.bin",
+  "src/generated/bangs-sparse.js",
   "src/generated/bangs-meta.js",
   "src/generated/bangs-trie.js",
 ] as const;
@@ -266,11 +262,8 @@ export function validateBangs(bangs: Bang[]): Bang[] {
   });
 }
 
-// NOTE: Custom escape functions produce smaller output than JSON.stringify,
-// which emits \uXXXX for characters that don't need escaping in practice.
-// Using single-quoted JS strings in generateMin also avoids the double-escape
-// problem where JSON.stringify(jsonString) escapes every " to \", nearly
-// doubling the output size.
+// Custom escape functions produce smaller generated modules than
+// JSON.stringify, which emits \uXXXX for characters that do not need it.
 
 function escapeString(
   s: string,
@@ -361,17 +354,6 @@ function dedupeStrings(values: readonly string[]): {
   return { ids, unique };
 }
 
-function toBase64U8(values: readonly number[]): string {
-  return Buffer.from(Uint8Array.from(values)).toString("base64");
-}
-
-function toBase64U16(values: readonly number[]): string {
-  const arr = Uint16Array.from(values);
-  return Buffer.from(arr.buffer, arr.byteOffset, arr.byteLength).toString(
-    "base64"
-  );
-}
-
 function nextPow2(n: number): number {
   let p = 1;
   while (p < n) {
@@ -380,7 +362,11 @@ function nextPow2(n: number): number {
   return p;
 }
 
-interface PackedMinData {
+function align2(value: number): number {
+  return (value + 1) & ~1;
+}
+
+interface PackedBangData {
   entryCount: number;
   prefixIds: number[];
   suffixIdsPlusOne: number[];
@@ -393,11 +379,11 @@ interface PackedMinData {
   suffixBlob: ReturnType<typeof packBlob>;
 }
 
-function packMinData(bangs: Bang[]): PackedMinData {
+function packBangData(bangs: Bang[]): PackedBangData {
   const entryCount = bangs.length;
   if (entryCount > 0xffff) {
     throw new Error(
-      `bangs-min packed format requires <= 65535 entries, got ${entryCount}`
+      `Binary bang format requires <= 65535 entries, got ${entryCount}`
     );
   }
 
@@ -416,7 +402,7 @@ function packMinData(bangs: Bang[]): PackedMinData {
   const { ids: prefixIds, unique: uniquePrefixes } = dedupeStrings(prefixes);
   if (uniquePrefixes.length > 0xffff) {
     throw new Error(
-      `bangs-min packed format requires <= 65535 unique prefixes, got ${uniquePrefixes.length}`
+      `Binary bang format requires <= 65535 unique prefixes, got ${uniquePrefixes.length}`
     );
   }
 
@@ -437,7 +423,7 @@ function packMinData(bangs: Bang[]): PackedMinData {
     const id = uniqueSuffixes.length;
     if (id >= 0xffff) {
       throw new Error(
-        `bangs-min packed format requires <= 65535 unique suffixes, got ${id + 1}`
+        `Binary bang format requires <= 65535 unique suffixes, got ${id + 1}`
       );
     }
     uniqueSuffixes.push(suffix);
@@ -457,14 +443,14 @@ function packMinData(bangs: Bang[]): PackedMinData {
   for (const len of prefixBlob.lengths) {
     if (len > 0xffff) {
       throw new Error(
-        `bangs-min packed format requires prefix length <= 65535, got ${len}`
+        `Binary bang format requires prefix length <= 65535, got ${len}`
       );
     }
   }
   for (const len of suffixBlob.lengths) {
     if (len > 0xffff) {
       throw new Error(
-        `bangs-min packed format requires suffix length <= 65535, got ${len}`
+        `Binary bang format requires suffix length <= 65535, got ${len}`
       );
     }
   }
@@ -481,6 +467,91 @@ function packMinData(bangs: Bang[]): PackedMinData {
     uniqueSuffixes,
     triggers,
   };
+}
+
+function copyTypedArray(
+  output: Uint8Array,
+  offset: number,
+  values: Uint8Array | Uint16Array
+): number {
+  output.set(
+    new Uint8Array(values.buffer, values.byteOffset, values.byteLength),
+    offset
+  );
+  return offset + values.byteLength;
+}
+
+function generateBinary(bangs: readonly Bang[]): Uint8Array {
+  const packed = packBangData(bangs.filter((bang) => !bang.regex));
+  const encoder = new TextEncoder();
+  const triggerBytes = encoder.encode(packed.triggerBlob.blob);
+  const prefixBytes = encoder.encode(packed.prefixBlob.blob);
+  const suffixBytes = encoder.encode(packed.suffixBlob.blob);
+  const triggerLengths =
+    packed.triggerLensKind === "u8"
+      ? Uint8Array.from(packed.triggerBlob.lengths)
+      : Uint16Array.from(packed.triggerBlob.lengths);
+  const prefixLengths = Uint16Array.from(packed.prefixBlob.lengths);
+  const suffixLengths = Uint16Array.from(packed.suffixBlob.lengths);
+  const prefixIds = Uint16Array.from(packed.prefixIds);
+  const suffixIds = Uint16Array.from(packed.suffixIdsPlusOne);
+
+  const hashSize = nextPow2(Math.max(2, Math.ceil(packed.entryCount / 0.55)));
+  const hashTable = new Uint16Array(hashSize);
+  const hashMask = hashSize - 1;
+  for (let i = 0; i < packed.triggers.length; i++) {
+    let slot = hashFNV1a(packed.triggers[i]) & hashMask;
+    while (hashTable[slot] !== 0) {
+      slot = (slot + 1) & hashMask;
+    }
+    hashTable[slot] = i + 1;
+  }
+
+  const headerWords = 12;
+  const headerBytes = headerWords * Uint32Array.BYTES_PER_ELEMENT;
+  let numericEnd = headerBytes + hashTable.byteLength;
+  numericEnd += triggerLengths.byteLength;
+  numericEnd = align2(numericEnd);
+  numericEnd +=
+    prefixLengths.byteLength +
+    suffixLengths.byteLength +
+    prefixIds.byteLength +
+    suffixIds.byteLength;
+  const totalBytes =
+    numericEnd +
+    triggerBytes.byteLength +
+    prefixBytes.byteLength +
+    suffixBytes.byteLength;
+  const output = new Uint8Array(new ArrayBuffer(totalBytes));
+  new Uint32Array(output.buffer, 0, headerWords).set([
+    0x31424246,
+    1,
+    packed.entryCount,
+    hashSize,
+    packed.triggerLensKind === "u8" ? 1 : 2,
+    packed.uniquePrefixes.length,
+    packed.uniqueSuffixes.length,
+    triggerBytes.byteLength,
+    prefixBytes.byteLength,
+    suffixBytes.byteLength,
+    numericEnd,
+    totalBytes,
+  ]);
+
+  let offset = headerBytes;
+  offset = copyTypedArray(output, offset, hashTable);
+  offset = copyTypedArray(output, offset, triggerLengths);
+  offset = align2(offset);
+  offset = copyTypedArray(output, offset, prefixLengths);
+  offset = copyTypedArray(output, offset, suffixLengths);
+  offset = copyTypedArray(output, offset, prefixIds);
+  offset = copyTypedArray(output, offset, suffixIds);
+  output.set(triggerBytes, offset);
+  offset += triggerBytes.byteLength;
+  output.set(prefixBytes, offset);
+  offset += prefixBytes.byteLength;
+  output.set(suffixBytes, offset);
+  return output;
 }
 
 function renderAdvancedLookup(bangs: readonly Bang[]): string {
@@ -603,324 +674,14 @@ function renderSnapLookup(overrides: readonly GeneratedSnapOverride[]): string {
   return `const _ST=[${definitions.join(",")}];${lookup}`;
 }
 
-function renderMinOpenAddress(
-  packed: PackedMinData,
-  advanced: readonly Bang[],
-  snapOverrides: readonly GeneratedSnapOverride[],
-  totalCount: number
-): string {
-  const {
-    entryCount,
-    triggerBlob,
-    triggerLensKind,
-    prefixBlob,
-    suffixBlob,
-    prefixIds,
-    suffixIdsPlusOne,
-    triggers,
-  } = packed;
-
-  const HASH_TARGET_LOAD = 0.55;
-  const hashSize = nextPow2(
-    Math.max(2, Math.ceil(entryCount / HASH_TARGET_LOAD))
-  );
-  if (hashSize > 0xffff) {
-    throw new Error(
-      `bangs-min packed format requires hash table size <= 65535, got ${hashSize}`
-    );
-  }
-
-  const hashTable = new Uint16Array(hashSize);
-  const hashMask = hashSize - 1;
-  for (let idx = 0; idx < entryCount; idx++) {
-    let slot = hashFNV1a(triggers[idx]) & hashMask;
-    while (hashTable[slot] !== 0) {
-      slot = (slot + 1) & hashMask;
-    }
-    hashTable[slot] = idx + 1;
-  }
-
-  let longestCluster = 0;
-  let currentCluster = 0;
-  for (let i = 0; i < hashSize * 2; i++) {
-    if (hashTable[i & hashMask] === 0) {
-      currentCluster = 0;
-    } else {
-      currentCluster++;
-      if (currentCluster > longestCluster) {
-        longestCluster = currentCluster;
-      }
-    }
-  }
-  console.log(
-    `  Hash table: size=${hashSize} load=${(entryCount / hashSize).toFixed(2)} longest_cluster=${longestCluster}`
-  );
-
-  const triggerLensB64 =
-    triggerLensKind === "u8"
-      ? toBase64U8(triggerBlob.lengths)
-      : toBase64U16(triggerBlob.lengths);
-  const prefixLensB64 = toBase64U16(prefixBlob.lengths);
-  const suffixLensB64 = toBase64U16(suffixBlob.lengths);
-  const prefixIdsB64 = toBase64U16(prefixIds);
-  const suffixIdsB64 = toBase64U16(suffixIdsPlusOne);
-  const hashTableB64 = Buffer.from(hashTable.buffer).toString("base64");
-
-  // Keep the packed tables private and materialize URL parts only for entries
-  // that are actually looked up.
-  return (
-    "const{_TB,_TL,_TO,_tuple,_HT,_HM}=(()=>{" +
-    "function _b64bytes(s){if(typeof atob==='function'){const b=atob(s);const n=b.length;const o=new Uint8Array(n);for(let i=0;i<n;i++){o[i]=b.charCodeAt(i)}return o}if(typeof Buffer!=='undefined'){const b=Buffer.from(s,'base64');return new Uint8Array(b.buffer,b.byteOffset,b.byteLength)}throw new Error('No base64 decoder available')}" +
-    "function _b64u8(s){return _b64bytes(s)}" +
-    "function _b64u16(s){const b=_b64bytes(s);if((b.byteOffset&1)===0){return new Uint16Array(b.buffer,b.byteOffset,b.byteLength>>>1)}const c=new Uint8Array(b.byteLength);c.set(b);return new Uint16Array(c.buffer)}" +
-    "function _off(lengths){const n=lengths.length;const o=new Uint32Array(n+1);let p=0;for(let i=0;i<n;i++){o[i]=p;p+=lengths[i]}o[n]=p;return o}" +
-    `const _TB='${jsEscape(triggerBlob.blob)}';` +
-    `const _TL=${triggerLensKind === "u8" ? `_b64u8('${triggerLensB64}')` : `_b64u16('${triggerLensB64}')`};` +
-    "const _TO=_off(_TL);" +
-    `const _PB='${jsEscape(prefixBlob.blob)}';` +
-    `const _PL=_b64u16('${prefixLensB64}');` +
-    "const _PO=_off(_PL);" +
-    `const _SB='${jsEscape(suffixBlob.blob)}';` +
-    `const _SL=_b64u16('${suffixLensB64}');` +
-    "const _SO=_off(_SL);" +
-    `const _EP=_b64u16('${prefixIdsB64}');` +
-    `const _ES=_b64u16('${suffixIdsB64}');` +
-    `const _HT=_b64u16('${hashTableB64}');` +
-    `const _HM=${hashMask};` +
-    "" +
-    "const _PC=[],_SC=[],_TC=[];" +
-    "function _prefix(id){let s=_PC[id];if(s!==undefined)return s;s=_PB.substring(_PO[id],_PO[id+1]);_PC[id]=s;return s}" +
-    "function _suffix(id){let s=_SC[id];if(s!==undefined)return s;s=_SB.substring(_SO[id],_SO[id+1]);_SC[id]=s;return s}" +
-    "function _tuple(idx){let c=_TC[idx];if(c!==undefined)return c;const s=_ES[idx];c=s===0?[_prefix(_EP[idx]),null]:[_prefix(_EP[idx]),_suffix(s-1)];_TC[idx]=c;return c}" +
-    "return{_TB,_TL,_TO,_tuple,_HT,_HM}" +
-    "})();" +
-    `export const BANG_COUNT=${totalCount};` +
-    "export function lookupBang(trigger,h){let slot=(h>>>0)&_HM;for(;;){const ep=_HT[slot];if(ep===0){return null}const idx=ep-1;if(_TL[idx]===trigger.length&&_TB.startsWith(trigger,_TO[idx]))return _tuple(idx);slot=(slot+1)&_HM}}" +
-    renderAdvancedLookup(advanced) +
-    renderSnapLookup(snapOverrides)
-  );
-}
-
-type StringOrderMode = "lex" | "lenlex";
-type MinCandidateLabel = "insertion" | StringOrderMode;
-
-const BROTLI_SORT_ORDERS: readonly StringOrderMode[] = ["lex", "lenlex"];
-const BROTLI_EVAL_RUNS = 9;
-const BROTLI_MAX_QUALITY_PARAMS: BrotliOptions["params"] = {
-  [zlibConstants.BROTLI_PARAM_QUALITY]: zlibConstants.BROTLI_MAX_QUALITY,
-};
-
-interface ReorderMap {
-  newStrings: string[];
-  oldToNew: number[];
-}
-
-function reorderUniqueStrings(
-  values: readonly string[],
-  mode: StringOrderMode
-): ReorderMap {
-  const order = values.map((_, i) => i);
-  if (mode === "lex") {
-    order.sort((a, b) => values[a].localeCompare(values[b]));
-  } else {
-    order.sort((a, b) => {
-      const la = values[a].length;
-      const lb = values[b].length;
-      if (la !== lb) {
-        return lb - la;
-      }
-      return values[a].localeCompare(values[b]);
-    });
-  }
-  const oldToNew = new Array<number>(values.length);
-  const newStrings = new Array<string>(values.length);
-  for (let i = 0; i < order.length; i++) {
-    const oldIdx = order[i];
-    oldToNew[oldIdx] = i;
-    newStrings[i] = values[oldIdx];
-  }
-  return { newStrings, oldToNew };
-}
-
-function reorderPackedForBrotli(
-  packed: PackedMinData,
-  mode: StringOrderMode
-): PackedMinData {
-  const prefixRemap = reorderUniqueStrings(packed.uniquePrefixes, mode);
-  const suffixRemap = reorderUniqueStrings(packed.uniqueSuffixes, mode);
-  const prefixIds = new Array<number>(packed.prefixIds.length);
-  const suffixIdsPlusOne = new Array<number>(packed.suffixIdsPlusOne.length);
-  for (let i = 0; i < packed.prefixIds.length; i++) {
-    prefixIds[i] = prefixRemap.oldToNew[packed.prefixIds[i]];
-  }
-  for (let i = 0; i < packed.suffixIdsPlusOne.length; i++) {
-    const old = packed.suffixIdsPlusOne[i];
-    suffixIdsPlusOne[i] = old === 0 ? 0 : suffixRemap.oldToNew[old - 1] + 1;
-  }
-  return {
-    ...packed,
-    prefixIds,
-    suffixIdsPlusOne,
-    uniquePrefixes: prefixRemap.newStrings,
-    uniqueSuffixes: suffixRemap.newStrings,
-    prefixBlob: packBlob(prefixRemap.newStrings),
-    suffixBlob: packBlob(suffixRemap.newStrings),
-  };
-}
-
-function medianNs(values: readonly number[]): number {
-  const sorted = values.slice().sort((a, b) => a - b);
-  return sorted[Math.floor(sorted.length / 2)];
-}
-
-function estimateEvalNs(source: string, runs = BROTLI_EVAL_RUNS): number {
-  const evalCode = source
-    .replaceAll("export const ", "const ")
-    .replaceAll("export function ", "function ");
-  const times = new Array<number>(runs);
-  for (let i = 0; i < runs; i++) {
-    const t0 = Bun.nanoseconds();
-    // Parse+execute proxy in codegen for cold-start sensitive codegen choices.
-    new Function(evalCode)();
-    times[i] = Bun.nanoseconds() - t0;
-  }
-  return medianNs(times);
-}
-
-interface BrotliCandidate {
-  brBytes: number;
-  evalNs: number | null;
-  js: string;
-  label: MinCandidateLabel;
-}
-
-function buildBrotliCandidate(
-  label: MinCandidateLabel,
-  js: string,
-  brBytes: number
-): BrotliCandidate {
-  return { label, js, brBytes, evalNs: null };
-}
-
-interface BrotliCandidateInput {
-  js: string;
-  label: MinCandidateLabel;
-}
-
-function createBrotliCandidateInputs(
-  base: PackedMinData,
-  advanced: readonly Bang[],
-  snapOverrides: readonly GeneratedSnapOverride[],
-  totalCount: number
-): BrotliCandidateInput[] {
-  const inputs: BrotliCandidateInput[] = [
-    {
-      label: "insertion",
-      js: renderMinOpenAddress(base, advanced, snapOverrides, totalCount),
-    },
-  ];
-  for (const mode of BROTLI_SORT_ORDERS) {
-    const packed = reorderPackedForBrotli(base, mode);
-    inputs.push({
-      label: mode,
-      js: renderMinOpenAddress(packed, advanced, snapOverrides, totalCount),
-    });
-  }
-  return inputs;
-}
-
-function brotliSizeBytes(source: string): Promise<number> {
-  return new Promise((resolve, reject) => {
-    brotliCompress(
-      Buffer.from(source),
-      { params: BROTLI_MAX_QUALITY_PARAMS },
-      (error, output) => {
-        if (error) {
-          reject(error);
-          return;
-        }
-        resolve(output.byteLength);
-      }
-    );
-  });
-}
-
-async function buildBrotliCandidates(
-  base: PackedMinData,
-  advanced: readonly Bang[],
-  snapOverrides: readonly GeneratedSnapOverride[],
-  totalCount: number
-): Promise<BrotliCandidate[]> {
-  const inputs = createBrotliCandidateInputs(
-    base,
-    advanced,
-    snapOverrides,
-    totalCount
-  );
-  const compressedSizes = await Promise.all(
-    inputs.map((input) => brotliSizeBytes(input.js))
-  );
-  const candidates = new Array<BrotliCandidate>(inputs.length);
-  for (let i = 0; i < inputs.length; i++) {
-    const input = inputs[i];
-    candidates[i] = buildBrotliCandidate(
-      input.label,
-      input.js,
-      compressedSizes[i]
-    );
-  }
-  return candidates;
-}
-
-function selectBestCandidate(
-  candidates: readonly BrotliCandidate[]
-): BrotliCandidate {
-  let bestBrBytes = candidates[0].brBytes;
-  for (let i = 1; i < candidates.length; i++) {
-    if (candidates[i].brBytes < bestBrBytes) {
-      bestBrBytes = candidates[i].brBytes;
-    }
-  }
-  const finalists = candidates.filter(
-    (candidate) => candidate.brBytes === bestBrBytes
-  );
-  if (finalists.length === 1) {
-    return finalists[0];
-  }
-  let best = finalists[0];
-  best.evalNs = estimateEvalNs(best.js);
-  for (let i = 1; i < finalists.length; i++) {
-    const candidate = finalists[i];
-    candidate.evalNs = estimateEvalNs(candidate.js);
-    if (
-      (candidate.evalNs ?? Number.MAX_SAFE_INTEGER) <
-      (best.evalNs ?? Number.MAX_SAFE_INTEGER)
-    ) {
-      best = candidate;
-    }
-  }
-  return best;
-}
-
-async function generateMin(bangs: Bang[]): Promise<string> {
-  const advanced = bangs.filter((bang) => bang.regex);
-  const regular = bangs.filter((bang) => !bang.regex);
+function generateSparse(bangs: readonly Bang[]): string {
   const snapOverrides = collectSnapOverrides(bangs);
   console.log(`  Snap overrides: ${snapOverrides.length} generated`);
-  const base = packMinData(regular);
-  const candidates = await buildBrotliCandidates(
-    base,
-    advanced,
-    snapOverrides,
-    bangs.length
+  return (
+    `export const BANG_COUNT=${bangs.length};` +
+    renderAdvancedLookup(bangs.filter((bang) => bang.regex)) +
+    renderSnapLookup(snapOverrides)
   );
-  const best = selectBestCandidate(candidates);
-  console.log(
-    best.evalNs === null
-      ? `  bangs-min optimization: selected=${best.label} br=${best.brBytes}B`
-      : `  bangs-min optimization: selected=${best.label} br=${best.brBytes}B eval=${Math.round(best.evalNs)}ns (tie-break)`
-  );
-  return best.js;
 }
 
 function generateMeta(bangs: Bang[]): string {
@@ -1218,15 +979,13 @@ async function loadBangs(options: CodegenOptions): Promise<Bang[]> {
 }
 
 interface GeneratedArtifacts {
+  binary: Uint8Array;
   metaJs: string;
-  minJs: string;
+  sparseJs: string;
   trieJs: string;
 }
 
-async function buildGeneratedArtifacts(
-  bangs: Bang[]
-): Promise<GeneratedArtifacts> {
-  const minJsPromise = generateMin(bangs);
+function buildGeneratedArtifacts(bangs: Bang[]): GeneratedArtifacts {
   const trieRoot = buildRadixTrie(
     bangs,
     (b) => b.trigger,
@@ -1234,10 +993,10 @@ async function buildGeneratedArtifacts(
   );
   const trieData = flattenTrie(trieRoot);
   const trieRuntimeHelpers = buildMinifiedTrieRuntimeHelpers();
-  const minJs = await minJsPromise;
   return {
-    minJs,
+    binary: generateBinary(bangs),
     metaJs: generateMeta(bangs),
+    sparseJs: generateSparse(bangs),
     trieJs: generateTrie(trieData, trieRuntimeHelpers),
   };
 }
@@ -1247,32 +1006,33 @@ async function writeGeneratedArtifacts(
   artifacts: GeneratedArtifacts
 ): Promise<void> {
   await Promise.all([
-    Bun.write(`${outDir}/bangs-min.js`, artifacts.minJs),
+    Bun.write(`${outDir}/bangs.bin`, artifacts.binary),
     Bun.write(`${outDir}/bangs-meta.js`, artifacts.metaJs),
+    Bun.write(`${outDir}/bangs-sparse.js`, artifacts.sparseJs),
     Bun.write(`${outDir}/bangs-trie.js`, artifacts.trieJs),
   ]);
-  console.log(`  bangs-min.js: ${artifacts.minJs.length} bytes`);
+  console.log(`  bangs.bin: ${artifacts.binary.byteLength} bytes`);
   console.log(`  bangs-meta.js: ${artifacts.metaJs.length} bytes`);
+  console.log(`  bangs-sparse.js: ${artifacts.sparseJs.length} bytes`);
   console.log(`  bangs-trie.js: ${artifacts.trieJs.length} bytes`);
 }
 
 async function writeGeneratedDeclarations(outDir: string): Promise<void> {
   await Promise.all([
     Bun.write(
-      `${outDir}/bangs-min.d.ts`,
-      [
-        "export declare const BANG_COUNT: number;",
-        "export declare function lookupBang(trigger: string, hash: number): readonly [string, string | null] | null;",
-        "export declare function lookupAdvancedBang(trigger: string): readonly [string, readonly string[], readonly number[], RegExp, number] | null;",
-        "export declare function lookupSnapOverride(trigger: string, hash: number, origin: boolean): string | null;",
-        "",
-      ].join("\n")
-    ),
-    Bun.write(
       `${outDir}/bangs-meta.d.ts`,
       [
         "export declare const BANGS: readonly string[];",
         "export declare const CAPTURE_INDEXES: readonly number[];",
+        "",
+      ].join("\n")
+    ),
+    Bun.write(
+      `${outDir}/bangs-sparse.d.ts`,
+      [
+        "export declare const BANG_COUNT: number;",
+        "export declare function lookupAdvancedBang(trigger: string): readonly [string, readonly string[], readonly number[], RegExp, number] | null;",
+        "export declare function lookupSnapOverride(trigger: string, hash: number, origin: boolean): string | null;",
         "",
       ].join("\n")
     ),
@@ -1301,7 +1061,7 @@ export async function runCodegen(options: CodegenOptions = {}): Promise<void> {
 
   console.log("=== Generate ===");
   await mkdir(GENERATED_OUT_DIR, { recursive: true });
-  const artifacts = await buildGeneratedArtifacts(bangs);
+  const artifacts = buildGeneratedArtifacts(bangs);
   await writeGeneratedArtifacts(GENERATED_OUT_DIR, artifacts);
   await writeGeneratedDeclarations(GENERATED_OUT_DIR);
   console.log(`Generated ${bangs.length} bangs in ${GENERATED_OUT_DIR}/`);

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -59,6 +59,7 @@ async function build() {
   await mkdir("dist", { recursive: true });
 
   await Promise.all([
+    Bun.write("dist/bangs.bin", Bun.file("src/generated/bangs.bin")),
     Bun.build({
       entrypoints: ["src/sw/sw.ts"],
       outdir: "dist",
@@ -67,6 +68,7 @@ async function build() {
       target: "browser",
       format: "esm",
       define: {
+        __BANG_DATA_ASSET__: '"/bangs.bin"',
         __CACHE_VERSION__: '"flashbang-dev"',
         __REQUIRED_APP_ASSETS__: "[]",
         __IS_DEV__: JSON.stringify(true),
@@ -81,8 +83,15 @@ async function build() {
   console.log(`Build done in ${(performance.now() - t).toFixed(0)}ms`);
 }
 
-const generated = Bun.file("src/generated/bangs-min.js");
-if (!(await generated.exists())) {
+const generated = [
+  Bun.file("src/generated/bangs.bin"),
+  Bun.file("src/generated/bangs-sparse.js"),
+  Bun.file("src/generated/bangs-meta.js"),
+  Bun.file("src/generated/bangs-trie.js"),
+];
+if (
+  !(await Promise.all(generated.map((file) => file.exists()))).every(Boolean)
+) {
   console.warn("Generated bang data not found. Running codegen...");
   await $`bun run codegen`;
 }

--- a/scripts/profile.ts
+++ b/scripts/profile.ts
@@ -16,7 +16,7 @@ import {
 import type { RedirectSettings } from "../src/sw/redirect";
 import { ensureGeneratedBangData, GENERATED_BANG_DATA_FILES } from "./codegen";
 
-const [minPath, metaPath, triePath] = GENERATED_BANG_DATA_FILES;
+const [binaryPath, sparsePath, metaPath, triePath] = GENERATED_BANG_DATA_FILES;
 
 interface ProfileOptions {
   quick: boolean;
@@ -381,9 +381,11 @@ let sink = 0;
 import { hashFNV1a as fnvHash } from "../src/shared/hash";
 
 await ensureGeneratedBangData(true);
+const { initializeBangData, lookupBang } = await import("../src/sw/bang-data");
+initializeBangData(await Bun.file("src/generated/bangs.bin").arrayBuffer());
 
 const [
-  { BANG_COUNT, lookupBang },
+  { BANG_COUNT },
   { EDGES, NODES, ROOT, TERM_K_BLOB, TERM_K_OFF },
   { handleSuggestRequest },
   {
@@ -397,7 +399,7 @@ const [
   { readQueryParam, readTwoQueryParams },
   { BANGS },
 ] = await Promise.all([
-  import("../src/generated/bangs-min.js"),
+  import("../src/generated/bangs-sparse.js"),
   import("../src/generated/bangs-trie.js"),
   import("../src/server/handlers"),
   import("../src/suggest-bang"),
@@ -437,14 +439,18 @@ console.log(
 
 separator("1. DATA SIZE & STRUCTURE ANALYSIS");
 
-const minBytes = Bun.file(minPath).size;
 const metaBytes = Bun.file(metaPath).size;
 const trieBytes = Bun.file(triePath).size;
-const totalGeneratedBytes = minBytes + metaBytes + trieBytes;
+const binaryBytes = Bun.file(binaryPath).size;
+const sparseBytes = Bun.file(sparsePath).size;
+const totalGeneratedBytes = binaryBytes + sparseBytes + metaBytes + trieBytes;
 
 console.log(`\nBang count: ${BANG_COUNT.toLocaleString()}`);
 console.log(
-  `bangs-min.js:  ${fmtBytesExact(minBytes)}  (trigger→URL parts, used by SW)`
+  `bangs.bin:       ${fmtBytesExact(binaryBytes)}  (trigger→URL parts, used by SW)`
+);
+console.log(
+  `bangs-sparse.js: ${fmtBytesExact(sparseBytes)}  (advanced bangs + snap overrides, used by SW)`
 );
 console.log(
   `bangs-meta.js: ${fmtBytesExact(metaBytes)}  (packed catalog metadata, used by UI)`
@@ -454,7 +460,7 @@ const trieFile = await Bun.file(triePath).text();
 console.log(
   `bangs-trie.js: ${fmtBytesExact(trieBytes)}  (radix trie, used by suggest)`
 );
-console.log(`Total generated: ${fmtBytesExact(totalGeneratedBytes)}`);
+console.log(`Production generated: ${fmtBytesExact(totalGeneratedBytes)}`);
 console.log(
   `Avg bytes per bang: ${Math.round(totalGeneratedBytes / BANG_COUNT).toLocaleString()}B`
 );
@@ -1188,31 +1194,11 @@ console.log(
 
 separator("11. MODULE PARSE/EVAL TIME");
 
-const minFile = await Bun.file(minPath).text();
 const fullFile = await Bun.file(metaPath).text();
-const minEvalCode = minFile
-  .replaceAll("export const ", "const ")
-  .replaceAll("export function ", "function ");
 const fullEvalCode = fullFile.replaceAll("export const ", "const ");
 const trieEvalCode = trieFile.replace(/export const /g, "var ");
 
 const EVAL_RUNS = profileOptions.quick ? 8 : 20;
-
-const evalMinTimes: number[] = [];
-for (let i = 0; i < EVAL_RUNS; i++) {
-  const t0 = Bun.nanoseconds();
-  new Function(`${minEvalCode};${i}`)();
-  evalMinTimes.push(Bun.nanoseconds() - t0);
-}
-const evalMinStats = summarizeRuns(evalMinTimes);
-
-console.log(`\nbangs-min.js eval time (${fmtBytesExact(minBytes)}):`);
-console.log(`  Median: ${fmt(evalMinStats.p50)}`);
-console.log(`  p90:    ${fmt(evalMinStats.p90)}`);
-console.log(`  p99:    ${fmt(evalMinStats.p99)}`);
-console.log(
-  `  Spread: ${fmt(evalMinStats.min)}..${fmt(evalMinStats.max)} (cv ${evalMinStats.cvPct.toFixed(1)}%)`
-);
 
 const evalFullTimes: number[] = [];
 for (let i = 0; i < EVAL_RUNS; i++) {
@@ -1273,12 +1259,6 @@ function pointMetric(
 }
 
 const summaryRows: ProfileMetric[] = [
-  metric(
-    "module-eval.min",
-    "Module eval (bangs-min.js)",
-    "Cold start",
-    evalMinStats
-  ),
   metric(
     "module-eval.meta",
     "Module eval (bangs-meta.js)",

--- a/scripts/profile.ts
+++ b/scripts/profile.ts
@@ -382,7 +382,7 @@ import { hashFNV1a as fnvHash } from "../src/shared/hash";
 
 await ensureGeneratedBangData(true);
 const { initializeBangData, lookupBang } = await import("../src/sw/bang-data");
-initializeBangData(await Bun.file("src/generated/bangs.bin").arrayBuffer());
+initializeBangData(await Bun.file(binaryPath).arrayBuffer());
 
 const [
   { BANG_COUNT },

--- a/scripts/shared.ts
+++ b/scripts/shared.ts
@@ -3,6 +3,7 @@ import { $ } from "bun";
 
 const CUSTOM_SUGGEST_OPTION_MARKER = "<!-- custom-suggest-provider-option -->";
 const CUSTOM_SUGGEST_OPTION = '<option value="custom">Custom</option>';
+const BANG_DATA_ASSET_MARKER = "__BANG_DATA_ASSET__";
 export const DIST_DIR = process.env.DIST_DIR || "dist";
 
 export function customSuggestUrlsEnabled(
@@ -22,6 +23,13 @@ export function configureCustomSuggestOption(
     CUSTOM_SUGGEST_OPTION_MARKER,
     enabled ? CUSTOM_SUGGEST_OPTION : ""
   );
+}
+
+export function configureBangDataAsset(
+  html: string,
+  assetPath: string
+): string {
+  return html.replaceAll(BANG_DATA_ASSET_MARKER, assetPath);
 }
 
 export async function bundleUI(
@@ -77,7 +85,8 @@ export async function generateCSS(quiet = false): Promise<void> {
 
 export async function buildHTMLAssets(
   css: string,
-  allowUnsafeCustomSuggestUrls = customSuggestUrlsEnabled()
+  allowUnsafeCustomSuggestUrls = customSuggestUrlsEnabled(),
+  bangDataAsset = "/bangs.bin"
 ): Promise<void> {
   const inlineCSS = (src: string) =>
     src.replace(
@@ -85,7 +94,10 @@ export async function buildHTMLAssets(
       `<style>${css}</style>`
     );
 
-  const indexHtml = await Bun.file("src/ui/index.html").text();
+  const indexHtml = configureBangDataAsset(
+    await Bun.file("src/ui/index.html").text(),
+    bangDataAsset
+  );
   await Bun.write(
     `${DIST_DIR}/index.html`,
     minify(Buffer.from(indexHtml), { minify_css: true, minify_js: true })
@@ -95,7 +107,10 @@ export async function buildHTMLAssets(
     ["home", "src/ui/home/index.html"],
     ["bench", "src/ui/bench/index.html"],
   ] as const) {
-    const sourceHtml = await Bun.file(source).text();
+    const sourceHtml = configureBangDataAsset(
+      await Bun.file(source).text(),
+      bangDataAsset
+    );
     const html =
       name === "home"
         ? configureCustomSuggestOption(sourceHtml, allowUnsafeCustomSuggestUrls)
@@ -111,10 +126,11 @@ export async function buildHTMLAssets(
 }
 
 export async function assembleUIAssets(
-  allowUnsafeCustomSuggestUrls = customSuggestUrlsEnabled()
+  allowUnsafeCustomSuggestUrls = customSuggestUrlsEnabled(),
+  bangDataAsset = "/bangs.bin"
 ): Promise<void> {
   const css = await Bun.file(`${DIST_DIR}/styles.css`).text();
-  await buildHTMLAssets(css, allowUnsafeCustomSuggestUrls);
+  await buildHTMLAssets(css, allowUnsafeCustomSuggestUrls, bangDataAsset);
   await copyStaticAssets();
 }
 

--- a/scripts/start.ts
+++ b/scripts/start.ts
@@ -10,7 +10,8 @@ import { readPathname } from "../src/shared/raw-url";
 let securityHeaders = pageHeaders("");
 const IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable";
 const REVALIDATE_CACHE_CONTROL = "public, max-age=0, must-revalidate";
-const HASHED_CHUNK_RE = /^\/chunk-[a-z0-9_-]{8,}\.js$/i;
+const HASHED_ASSET_RE =
+  /^\/(?:chunk-[a-z0-9_-]{8,}\.js|bangs-[a-f0-9]{8,}\.bin)$/i;
 const DIST_DIR = process.env.DIST_DIR || "dist";
 const DIST_PREFIX = `${DIST_DIR}/`;
 
@@ -54,7 +55,7 @@ export function cacheControlForAsset(assetPath: string): string {
   if (assetPath === "/sw.js" || assetPath.endsWith(".html")) {
     return "no-cache";
   }
-  return HASHED_CHUNK_RE.test(assetPath)
+  return HASHED_ASSET_RE.test(assetPath)
     ? IMMUTABLE_CACHE_CONTROL
     : REVALIDATE_CACHE_CONTROL;
 }

--- a/src/sw/bang-data.ts
+++ b/src/sw/bang-data.ts
@@ -1,0 +1,135 @@
+export type BuiltinUrlParts = readonly [string, string | null];
+
+const MAGIC = 0x31424246;
+const VERSION = 1;
+const HEADER_WORDS = 12;
+const HEADER_BYTES = HEADER_WORDS * Uint32Array.BYTES_PER_ELEMENT;
+
+let lookup: ((trigger: string, hash: number) => BuiltinUrlParts | null) | null =
+  null;
+
+function offsets(lengths: Uint8Array | Uint16Array): Uint32Array {
+  const result = new Uint32Array(lengths.length + 1);
+  let position = 0;
+  for (let i = 0; i < lengths.length; i++) {
+    result[i] = position;
+    position += lengths[i];
+  }
+  result[lengths.length] = position;
+  return result;
+}
+
+export function initializeBangData(buffer: ArrayBuffer): void {
+  const header = new Uint32Array(buffer, 0, HEADER_WORDS);
+  if (header[0] !== MAGIC || header[1] !== VERSION) {
+    throw new Error("Unsupported binary bang data");
+  }
+  if (header[11] !== buffer.byteLength) {
+    throw new Error("Truncated binary bang data");
+  }
+
+  const entryCount = header[2];
+  const hashSize = header[3];
+  const triggerLengthWidth = header[4];
+  const prefixCount = header[5];
+  const suffixCount = header[6];
+  let offset = HEADER_BYTES;
+
+  const hashTable = new Uint16Array(buffer, offset, hashSize);
+  offset += hashTable.byteLength;
+  const triggerLengths =
+    triggerLengthWidth === 1
+      ? new Uint8Array(buffer, offset, entryCount)
+      : new Uint16Array(buffer, offset, entryCount);
+  offset += triggerLengths.byteLength;
+  offset = (offset + 1) & ~1;
+  const prefixLengths = new Uint16Array(buffer, offset, prefixCount);
+  offset += prefixLengths.byteLength;
+  const suffixLengths = new Uint16Array(buffer, offset, suffixCount);
+  offset += suffixLengths.byteLength;
+  const prefixIds = new Uint16Array(buffer, offset, entryCount);
+  offset += prefixIds.byteLength;
+  const suffixIds = new Uint16Array(buffer, offset, entryCount);
+  offset += suffixIds.byteLength;
+  if (offset !== header[10]) {
+    throw new Error("Invalid binary bang data layout");
+  }
+
+  const decoder = new TextDecoder();
+  const triggerBlob = decoder.decode(new Uint8Array(buffer, offset, header[7]));
+  offset += header[7];
+  const prefixBlob = decoder.decode(new Uint8Array(buffer, offset, header[8]));
+  offset += header[8];
+  const suffixBlob = decoder.decode(new Uint8Array(buffer, offset, header[9]));
+
+  const triggerOffsets = offsets(triggerLengths);
+  const prefixOffsets = offsets(prefixLengths);
+  const suffixOffsets = offsets(suffixLengths);
+  const prefixCache: string[] = [];
+  const suffixCache: string[] = [];
+  const tupleCache: BuiltinUrlParts[] = [];
+  const hashMask = hashSize - 1;
+
+  function prefix(id: number): string {
+    let value = prefixCache[id];
+    if (value === undefined) {
+      value = prefixBlob.substring(prefixOffsets[id], prefixOffsets[id + 1]);
+      prefixCache[id] = value;
+    }
+    return value;
+  }
+
+  function suffix(id: number): string {
+    let value = suffixCache[id];
+    if (value === undefined) {
+      value = suffixBlob.substring(suffixOffsets[id], suffixOffsets[id + 1]);
+      suffixCache[id] = value;
+    }
+    return value;
+  }
+
+  function tuple(index: number): BuiltinUrlParts {
+    let value = tupleCache[index];
+    if (value === undefined) {
+      const suffixId = suffixIds[index];
+      value =
+        suffixId === 0
+          ? [prefix(prefixIds[index]), null]
+          : [prefix(prefixIds[index]), suffix(suffixId - 1)];
+      tupleCache[index] = value;
+    }
+    return value;
+  }
+
+  lookup = (trigger, hash) => {
+    let slot = (hash >>> 0) & hashMask;
+    for (;;) {
+      const entry = hashTable[slot];
+      if (entry === 0) {
+        return null;
+      }
+      const index = entry - 1;
+      if (
+        triggerLengths[index] === trigger.length &&
+        triggerBlob.startsWith(trigger, triggerOffsets[index])
+      ) {
+        return tuple(index);
+      }
+      slot = (slot + 1) & hashMask;
+    }
+  };
+}
+
+export function isBangDataInitialized(): boolean {
+  return lookup !== null;
+}
+
+export function lookupBang(
+  trigger: string,
+  hash: number
+): BuiltinUrlParts | null {
+  if (!lookup) {
+    throw new Error("Binary bang data is not initialized");
+  }
+  return lookup(trigger, hash);
+}

--- a/src/sw/bang-data.ts
+++ b/src/sw/bang-data.ts
@@ -33,6 +33,12 @@ export function initializeBangData(buffer: ArrayBuffer): void {
   const triggerLengthWidth = header[4];
   const prefixCount = header[5];
   const suffixCount = header[6];
+  if (hashSize === 0 || (hashSize & (hashSize - 1)) !== 0) {
+    throw new Error("Invalid binary bang hash table size");
+  }
+  if (triggerLengthWidth !== 1 && triggerLengthWidth !== 2) {
+    throw new Error("Invalid binary bang trigger length width");
+  }
   let offset = HEADER_BYTES;
 
   const hashTable = new Uint16Array(buffer, offset, hashSize);

--- a/src/sw/idb.ts
+++ b/src/sw/idb.ts
@@ -1,4 +1,3 @@
-import { lookupBang } from "../generated/bangs-min.js";
 import {
   type CaptureUrlParts,
   type CustomBangRecord,
@@ -19,6 +18,7 @@ import {
 import { hashFNV1a } from "../shared/hash";
 import { idbWrap, openDB, resetDB } from "../shared/idb";
 import { compileSnapTarget, type SnapTargetParts } from "../shared/snap-target";
+import { lookupBang } from "./bang-data";
 import {
   buildTopFrecency,
   type TopFrecencyEntry,

--- a/src/sw/redirect.ts
+++ b/src/sw/redirect.ts
@@ -1,8 +1,7 @@
 import {
   lookupAdvancedBang,
-  lookupBang,
   lookupSnapOverride,
-} from "../generated/bangs-min.js";
+} from "../generated/bangs-sparse.js";
 import {
   CAPTURE_ENCODE_PLUS,
   CAPTURE_ENCODE_RAW,
@@ -23,6 +22,7 @@ import {
   CH_PLUS,
 } from "../shared/chars";
 import type { SnapTargetParts } from "../shared/snap-target";
+import { lookupBang } from "./bang-data";
 
 // NOTE: pos + char-width packed into one int to skip tuple alloc:
 //   findExcl/findSpace:         (pos << 2) | width        → >> 2 for pos, & 0b11 for width

--- a/src/sw/sw.ts
+++ b/src/sw/sw.ts
@@ -233,7 +233,7 @@ self.addEventListener("message", (e: ExtendableMessageEvent) => {
       if (cached) {
         resolve(cached);
       } else {
-        readRedirectSettings().then(resolve);
+        e.waitUntil(readRedirectSettings().then(resolve));
       }
     } else {
       e.waitUntil(

--- a/src/sw/sw.ts
+++ b/src/sw/sw.ts
@@ -5,6 +5,7 @@ import {
   encodeSuggestCookieValue,
   parseSuggestCookieValue,
 } from "../shared/suggest-cookie";
+import { initializeBangData, isBangDataInitialized } from "./bang-data";
 import {
   getCachedSettings,
   getTopFrecencyRecord,
@@ -17,6 +18,7 @@ import {
 import { type RedirectSettings, redirectRaw, redirectUrl } from "./redirect";
 
 declare const __CACHE_VERSION__: string;
+declare const __BANG_DATA_ASSET__: string;
 declare const __REQUIRED_APP_ASSETS__: string[];
 declare const __IS_DEV__: boolean;
 
@@ -25,6 +27,7 @@ const LEGACY_CACHE_NAMES = new Set(["flashbang-dev"]);
 const CACHE_NAME = __CACHE_VERSION__.startsWith(CACHE_PREFIX)
   ? __CACHE_VERSION__
   : `${CACHE_PREFIX}${__CACHE_VERSION__}`;
+const BANG_DATA_ASSET = __BANG_DATA_ASSET__;
 const APP_ASSETS = [
   "/home",
   "/app.js",
@@ -36,11 +39,41 @@ const APP_ASSETS = [
 const DEFERRED_ASSETS = [...APP_ASSETS, "/bench", "/bench.js"];
 const PRECACHE_CONCURRENCY = 4;
 let deferredPrecachePromise: Promise<void> | null = null;
+let bangDataPromise: Promise<void> | null = null;
 let benchmarkClientId: string | null = null;
 const RESOLVED_PROMISE: Promise<void> = Promise.resolve();
 const swallowError = () => {
   /* best-effort */
 };
+
+async function loadBangData(): Promise<void> {
+  const request = new Request(BANG_DATA_ASSET);
+  const cache = await caches.open(CACHE_NAME);
+  let response = await cache.match(request);
+  if (!response) {
+    response = await fetch(request);
+    if (!response.ok) {
+      throw new Error(
+        `Failed to load ${BANG_DATA_ASSET}: ${response.status} ${response.statusText}`
+      );
+    }
+    await cache.put(request, response.clone());
+  }
+  initializeBangData(await response.arrayBuffer());
+}
+
+function ensureBangData(): Promise<void> {
+  if (isBangDataInitialized()) {
+    return RESOLVED_PROMISE;
+  }
+  if (!bangDataPromise) {
+    bangDataPromise = loadBangData().catch((error) => {
+      bangDataPromise = null;
+      throw error;
+    });
+  }
+  return bangDataPromise;
+}
 
 async function precacheAssets(
   cacheName: string,
@@ -154,7 +187,7 @@ function queueBangSideEffects(e: FetchEvent, trigger: string): void {
 }
 
 self.addEventListener("install", (e: ExtendableEvent) => {
-  e.waitUntil(self.skipWaiting());
+  e.waitUntil(ensureBangData().then(() => self.skipWaiting()));
 });
 
 self.addEventListener("activate", (e: ExtendableEvent) => {
@@ -162,7 +195,7 @@ self.addEventListener("activate", (e: ExtendableEvent) => {
     Promise.all([
       deleteOldCaches(CACHE_NAME),
       self.clients.claim(),
-      readRedirectSettings(),
+      ensureBangData().then(() => readRedirectSettings()),
       loadFrecency(),
     ]).then(() => {
       /* no-op */
@@ -196,13 +229,41 @@ self.addEventListener("message", (e: ExtendableMessageEvent) => {
       });
     };
     const cached = getCachedSettings();
-    if (cached) {
-      resolve(cached);
+    if (isBangDataInitialized()) {
+      if (cached) {
+        resolve(cached);
+      } else {
+        readRedirectSettings().then(resolve);
+      }
     } else {
-      readRedirectSettings().then(resolve);
+      e.waitUntil(
+        ensureBangData().then(() => {
+          const readySettings = getCachedSettings();
+          if (readySettings) {
+            resolve(readySettings);
+            return;
+          }
+          return readRedirectSettings().then(resolve);
+        })
+      );
     }
   }
 });
+
+function respondToRedirect(
+  e: FetchEvent,
+  rawQuery: string,
+  settings: RedirectSettings
+): Response {
+  const [response, trigger] = redirectRaw(rawQuery, settings);
+  if (
+    trigger &&
+    (benchmarkClientId === null || e.clientId !== benchmarkClientId)
+  ) {
+    queueBangSideEffects(e, trigger);
+  }
+  return response;
+}
 
 self.addEventListener("fetch", (e: FetchEvent) => {
   const raw = e.request.url;
@@ -217,27 +278,27 @@ self.addEventListener("fetch", (e: FetchEvent) => {
     const rawQ =
       vEnd === -1 ? raw.substring(vStart) : raw.substring(vStart, vEnd);
     if (rawQ) {
-      const cached = getCachedSettings();
-      if (cached) {
-        const [resp, trigger] = redirectRaw(rawQ, cached);
-        if (
-          trigger &&
-          (benchmarkClientId === null || e.clientId !== benchmarkClientId)
-        ) {
-          queueBangSideEffects(e, trigger);
+      if (isBangDataInitialized()) {
+        const cached = getCachedSettings();
+        if (cached) {
+          e.respondWith(respondToRedirect(e, rawQ, cached));
+        } else {
+          e.respondWith(
+            readRedirectSettings().then((settings) =>
+              respondToRedirect(e, rawQ, settings)
+            )
+          );
         }
-        e.respondWith(resp);
       } else {
         e.respondWith(
-          readRedirectSettings().then((s) => {
-            const [resp, trigger] = redirectRaw(rawQ, s);
-            if (
-              trigger &&
-              (benchmarkClientId === null || e.clientId !== benchmarkClientId)
-            ) {
-              queueBangSideEffects(e, trigger);
+          ensureBangData().then(() => {
+            const cached = getCachedSettings();
+            if (cached) {
+              return respondToRedirect(e, rawQ, cached);
             }
-            return resp;
+            return readRedirectSettings().then((settings) =>
+              respondToRedirect(e, rawQ, settings)
+            );
           })
         );
       }

--- a/src/ui/home/index.html
+++ b/src/ui/home/index.html
@@ -8,6 +8,12 @@
     <link rel="icon" type="image/svg+xml" href="/icon.svg">
     <link rel="manifest" href="/manifest.json">
     <link
+      rel="preload"
+      as="fetch"
+      href="__BANG_DATA_ASSET__"
+      crossorigin="anonymous"
+    >
+    <link
       rel="search"
       type="application/opensearchdescription+xml"
       title="flashbang"

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -10,7 +10,12 @@
       title="flashbang"
       href="/opensearch.xml"
     >
-    <link rel="preload" as="script" href="/sw.js">
+    <link
+      rel="preload"
+      as="fetch"
+      href="__BANG_DATA_ASSET__"
+      crossorigin="anonymous"
+    >
     <style>
     html {
       background: #0a0a0f;

--- a/tests/bang-catalog.test.ts
+++ b/tests/bang-catalog.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { BANG_COUNT } from "../src/generated/bangs-min.js";
+import { BANG_COUNT } from "../src/generated/bangs-sparse.js";
 import {
   createBangMeta,
   loadBuiltinBangCatalog,

--- a/tests/build-cache.test.ts
+++ b/tests/build-cache.test.ts
@@ -5,6 +5,7 @@ import {
   requiredAppAssetPaths,
 } from "../scripts/build";
 import {
+  configureBangDataAsset,
   configureCustomSuggestOption,
   customSuggestUrlsEnabled,
 } from "../scripts/shared";
@@ -47,6 +48,7 @@ describe("build cache version", () => {
 
   test("maps every concrete core and chunk precache input", () => {
     expect(precacheFileInputs(["/chunk-abc12345.js"])).toEqual([
+      ["/bangs.bin", "dist/bangs.bin"],
       ["/home", "dist/home.html"],
       ["/bench", "dist/bench.html"],
       ["/bench.js", "dist/bench.js"],
@@ -54,6 +56,13 @@ describe("build cache version", () => {
       ["/icon.svg", "dist/icon.svg"],
       ["/manifest.json", "dist/manifest.json"],
       ["/chunk-abc12345.js", "dist/chunk-abc12345.js"],
+    ]);
+  });
+
+  test("maps a content-hashed binary asset", () => {
+    expect(precacheFileInputs([], "/bangs-0123456789ab.bin")[0]).toEqual([
+      "/bangs-0123456789ab.bin",
+      "dist/bangs-0123456789ab.bin",
     ]);
   });
 
@@ -94,5 +103,16 @@ describe("custom suggestion build flag", () => {
     const html = configureCustomSuggestOption(source, true);
     expect(html).toContain('<option value="custom">Custom</option>');
     expect(html).not.toContain("custom-suggest-provider-option");
+  });
+});
+
+describe("bang data asset injection", () => {
+  test("replaces the generated binary path marker", () => {
+    expect(
+      configureBangDataAsset(
+        '<link href="__BANG_DATA_ASSET__">',
+        "/bangs-0123456789ab.bin"
+      )
+    ).toBe('<link href="/bangs-0123456789ab.bin">');
   });
 });

--- a/tests/codegen-roundtrip.test.ts
+++ b/tests/codegen-roundtrip.test.ts
@@ -4,7 +4,7 @@ import {
   lookupSnapOverride,
 } from "../src/generated/bangs-sparse.js";
 import { hashFNV1a } from "../src/shared/hash";
-import { lookupBang } from "../src/sw/bang-data";
+import { initializeBangData, lookupBang } from "../src/sw/bang-data";
 import { loadTestBangData } from "./helpers/bang-data";
 
 await loadTestBangData();
@@ -78,6 +78,20 @@ describe("codegen round-trip", () => {
     expect(header[1]).toBe(1);
     expect(header[2]).toBe(bangs.filter((bang) => !bang.regex).length);
     expect(header[11]).toBe(binary.byteLength);
+  });
+
+  test("rejects invalid binary lookup metadata", async () => {
+    const binary = await Bun.file("src/generated/bangs.bin").arrayBuffer();
+    for (const [word, value, message] of [
+      [3, 0, "Invalid binary bang hash table size"],
+      [3, 3, "Invalid binary bang hash table size"],
+      [4, 0, "Invalid binary bang trigger length width"],
+      [4, 3, "Invalid binary bang trigger length width"],
+    ] as const) {
+      const invalid = binary.slice(0);
+      new Uint32Array(invalid, 0, 12)[word] = value;
+      expect(() => initializeBangData(invalid)).toThrow(message);
+    }
   });
 
   test("regex bangs are emitted only through the sparse advanced lookup", () => {

--- a/tests/codegen-roundtrip.test.ts
+++ b/tests/codegen-roundtrip.test.ts
@@ -1,17 +1,19 @@
 import { describe, expect, test } from "bun:test";
 import {
   lookupAdvancedBang,
-  lookupBang,
   lookupSnapOverride,
-} from "../src/generated/bangs-min.js";
+} from "../src/generated/bangs-sparse.js";
 import { hashFNV1a } from "../src/shared/hash";
+import { lookupBang } from "../src/sw/bang-data";
+import { loadTestBangData } from "./helpers/bang-data";
+
+await loadTestBangData();
 
 const bangs: Array<{ regex?: string; trigger: string; url: string }> =
   await Bun.file("data/bangs.json").json();
 const customBangs: Record<string, { url: string }> = await Bun.file(
   "data/custom-bangs.json"
 ).json();
-const generatedSource = await Bun.file("src/generated/bangs-min.js").text();
 
 describe("codegen round-trip", () => {
   test("every 100th bang resolves to a non-null entry", () => {
@@ -69,11 +71,13 @@ describe("codegen round-trip", () => {
     expect(lookupBang("g", hash)).toBe(first);
   });
 
-  test("keeps triggers and URL parts packed during initialization", () => {
-    expect(generatedSource).not.toContain("const _TS=");
-    expect(generatedSource).not.toContain("_TC[_i]=");
-    expect(generatedSource).toContain("_TB.startsWith(trigger,_TO[idx])");
-    expect(generatedSource).toContain("function _tuple(idx)");
+  test("emits the binary lookup artifact", async () => {
+    const binary = await Bun.file("src/generated/bangs.bin").arrayBuffer();
+    const header = new Uint32Array(binary, 0, 12);
+    expect(header[0]).toBe(0x31424246);
+    expect(header[1]).toBe(1);
+    expect(header[2]).toBe(bangs.filter((bang) => !bang.regex).length);
+    expect(header[11]).toBe(binary.byteLength);
   });
 
   test("regex bangs are emitted only through the sparse advanced lookup", () => {

--- a/tests/e2e/flashbang.e2e.ts
+++ b/tests/e2e/flashbang.e2e.ts
@@ -1540,8 +1540,17 @@ test("worker activation creates its cache and removes the old cache", async ({
     `${process.env.DIST_DIR || "dist"}/sw.js`,
     "utf8"
   );
+  const indexSource = await readFile(
+    `${process.env.DIST_DIR || "dist"}/index.html`,
+    "utf8"
+  );
   const builtCacheName = workerSource.match(/fb-[a-f0-9]{8}/)?.[0];
+  const builtBangDataAsset = workerSource.match(
+    /\/bangs-[a-f0-9]{12}\.bin/
+  )?.[0];
   expect(builtCacheName).toBeDefined();
+  expect(builtBangDataAsset).toBeDefined();
+  expect(indexSource).toContain(builtBangDataAsset!);
   const initialCacheName = "fb-e2e-initial";
   const lifecyclePage = await context.newPage();
   await lifecyclePage.goto("/health");
@@ -1557,6 +1566,17 @@ test("worker activation creates its cache and removes the old cache", async ({
   await expect
     .poll(() => lifecyclePage.evaluate(() => caches.keys()))
     .toContain(builtCacheName!);
+  await expect
+    .poll(() =>
+      lifecyclePage.evaluate(
+        async ({ assetPath, cacheName }) => {
+          const cache = await caches.open(cacheName);
+          return Boolean(await cache.match(assetPath));
+        },
+        { cacheName: builtCacheName!, assetPath: builtBangDataAsset! }
+      )
+    )
+    .toBe(true);
   await expect
     .poll(() => lifecyclePage.evaluate(() => caches.keys()))
     .not.toContain(initialCacheName);

--- a/tests/helpers/bang-data.ts
+++ b/tests/helpers/bang-data.ts
@@ -1,0 +1,12 @@
+import { initializeBangData } from "../../src/sw/bang-data";
+
+let loadPromise: Promise<void> | null = null;
+
+export function loadTestBangData(): Promise<void> {
+  if (!loadPromise) {
+    loadPromise = Bun.file("src/generated/bangs.bin")
+      .arrayBuffer()
+      .then(initializeBangData);
+  }
+  return loadPromise;
+}

--- a/tests/redirect-perf.test.ts
+++ b/tests/redirect-perf.test.ts
@@ -4,6 +4,9 @@ import { compileCaptureUrl } from "../src/shared/capture-template";
 import { compileSnapTarget } from "../src/shared/snap-target";
 import type { UrlParts } from "../src/sw/redirect";
 import { type RedirectSettings, redirectRaw } from "../src/sw/redirect";
+import { loadTestBangData } from "./helpers/bang-data";
+
+await loadTestBangData();
 
 const DEFAULT_URL: UrlParts = ["https://www.google.com/search?q=", ""];
 const LUCKY_URL: UrlParts = ["https://www.google.com/search?btnI&q=", ""];

--- a/tests/redirect.test.ts
+++ b/tests/redirect.test.ts
@@ -7,6 +7,9 @@ import {
   redirectRaw as redirectRawTuple,
   redirectUrl,
 } from "../src/sw/redirect";
+import { loadTestBangData } from "./helpers/bang-data";
+
+await loadTestBangData();
 
 function redirectRaw(rawQuery: string, settings: RedirectSettings): Response {
   return redirectRawTuple(rawQuery, settings)[0];

--- a/tests/start-cache.test.ts
+++ b/tests/start-cache.test.ts
@@ -16,8 +16,11 @@ describe("production static caching", () => {
     expect(acceptsBrotli("xbr, gzip")).toBe(false);
   });
 
-  test("only content-hashed chunks are immutable", () => {
+  test("only content-hashed assets are immutable", () => {
     expect(cacheControlForAsset("/chunk-abc12345.js")).toBe(
+      "public, max-age=31536000, immutable"
+    );
+    expect(cacheControlForAsset("/bangs-0123456789ab.bin")).toBe(
       "public, max-age=31536000, immutable"
     );
     for (const path of [

--- a/tests/sw-idb.test.ts
+++ b/tests/sw-idb.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { redirectUrl } from "../src/sw/redirect";
+import { loadTestBangData } from "./helpers/bang-data";
 import { installFakeIndexedDb, reqToPromise } from "./helpers/fake-indexeddb";
+
+await loadTestBangData();
 
 let restoreIndexedDb: (() => void) | null = null;
 let swIdbModule: typeof import("../src/sw/idb");

--- a/tests/sw-runtime.test.ts
+++ b/tests/sw-runtime.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { loadTestBangData } from "./helpers/bang-data";
 import { installFakeIndexedDb, reqToPromise } from "./helpers/fake-indexeddb";
 
 type SwHandler = (event: unknown) => Promise<void> | void;
@@ -180,6 +181,7 @@ async function loadSwRuntime(requiredAppAssets: readonly string[] = []) {
 }
 
 beforeEach(async () => {
+  await loadTestBangData();
   restoreIndexedDb = installFakeIndexedDb();
   const swIdb = await import("../src/sw/idb");
   swIdb.invalidateCache();
@@ -278,7 +280,8 @@ describe("sw runtime with real modules", () => {
       }
     );
     await handlers.message?.(redirectEvt.event);
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(redirectEvt.waits).toHaveLength(1);
+    await Promise.all(redirectEvt.waits);
     expect(String((posted[0] as { url: string }).url)).toContain("google.com");
 
     // Change default bang, invalidate cache, and verify redirect reflects new settings.
@@ -295,7 +298,8 @@ describe("sw runtime with real modules", () => {
       }
     );
     await handlers.message?.(redirectEvt2.event);
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(redirectEvt2.waits).toHaveLength(1);
+    await Promise.all(redirectEvt2.waits);
     expect(String((postedAfterInvalidate[0] as { url: string }).url)).toContain(
       "duckduckgo.com"
     );

--- a/tests/sw-runtime.test.ts
+++ b/tests/sw-runtime.test.ts
@@ -53,6 +53,7 @@ function setupSwGlobals(requiredAppAssets: readonly string[] = []) {
   fetchImpl = () => Promise.resolve(new Response("ok"));
 
   const globals = globalThis as unknown as Record<string, unknown>;
+  globals.__BANG_DATA_ASSET__ = "/bangs.bin";
   globals.__CACHE_VERSION__ = "test-cache";
   globals.__REQUIRED_APP_ASSETS__ = [...requiredAppAssets];
   globals.__IS_DEV__ = false;


### PR DESCRIPTION
## Summary
- replace the generated JavaScript bang lookup with a packed binary artifact and sparse advanced lookup module
- load and cache binary bang data safely across Service Worker install, activation, restart, and offline paths
- emit a content-hashed immutable binary asset and preload it from production HTML
- remove the obsolete `bangs-min.js` generator and update profiling, docs, and tests

## Performance
- production `sw.js`: 40.0 KiB raw / 10.9 KiB Brotli
- `bangs.bin`: 763.6 KiB raw / 244.4 KiB Brotli
- binary setup measured around 0.45 ms versus 1.5-1.6 ms for JavaScript parse/eval, with unchanged warm lookup speed
- production preload reduced fresh activation by 27-212 ms in Chromium and 41-224 ms in Firefox across simulated network profiles
- WebKit activation remained within -7 to +2 ms, but WebKit performs a second binary request on first install

## Validation
- `bun test` (373 passed)
- `bun run typecheck`
- `bunx biome check`
- `bun run build`
- `bun run profile:quick`
- `bun run test:e2e` (103 passed, 4 expected skips)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved service worker redirect handling by loading bang data efficiently and caching it for reuse.
  * Added preloading and content-hashed delivery for bang data assets.
  * Enhanced production caching for generated bang data.

* **Bug Fixes**
  * Improved build-time detection and generation of required bang data artifacts.

* **Documentation**
  * Updated development and build documentation to reflect the new generated data workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->