### PR TITLE
Add browser-specific address bar setup guides

### DIFF
--- a/src/ui/home/address-bar-setup.ts
+++ b/src/ui/home/address-bar-setup.ts
@@ -131,6 +131,7 @@ export function setupAddressBarSheet(): void {
   const searchUrl = $<HTMLInputElement>("#setup-search-url");
   const suggestUrl = $<HTMLInputElement>("#setup-suggest-url");
   const browserTabs = $("#setup-browser-tabs");
+  const browserPanel = $("#setup-browser-panel");
   const browserName = $("#setup-browser-name");
   const browserSteps = $("#setup-browser-steps");
   const browserDocs = $<HTMLAnchorElement>("#setup-browser-docs");
@@ -145,6 +146,9 @@ export function setupAddressBarSheet(): void {
       const selected = button.dataset.browser === browser;
       button.setAttribute("aria-selected", String(selected));
       button.tabIndex = selected ? 0 : -1;
+      if (selected) {
+        browserPanel.setAttribute("aria-labelledby", button.id);
+      }
       button.classList.remove(...ACTIVE_TAB_CLASSES, ...INACTIVE_TAB_CLASSES);
       button.classList.add(
         ...(selected ? ACTIVE_TAB_CLASSES : INACTIVE_TAB_CLASSES)
@@ -264,6 +268,7 @@ export function setupAddressBarSheet(): void {
           label
         );
         button.type = "button";
+        button.id = `setup-browser-tab-${id}`;
         button.role = "tab";
         button.dataset.browser = id;
         button.setAttribute("aria-controls", "setup-browser-panel");

--- a/src/ui/home/address-bar-setup.ts
+++ b/src/ui/home/address-bar-setup.ts
@@ -1,6 +1,127 @@
 import { copyText } from "../clipboard";
-import { $ } from "../dom";
+import { $, el } from "../dom";
 import { setupDialog } from "../modal";
+
+type AddressBarBrowser = "brave" | "chrome" | "edge" | "firefox" | "safari";
+
+interface BrowserGuide {
+  docsLabel: string;
+  docsUrl: string;
+  name: string;
+  settingsUrl?: string;
+  steps: readonly string[];
+  warning?: {
+    label: string;
+    text: string;
+  };
+}
+
+const BROWSER_TABS: ReadonlyArray<{
+  id: AddressBarBrowser;
+  label: string;
+}> = [
+  { id: "chrome", label: "Chrome" },
+  { id: "edge", label: "Edge" },
+  { id: "firefox", label: "Firefox" },
+  { id: "brave", label: "Brave" },
+  { id: "safari", label: "Safari" },
+];
+
+const ACTIVE_TAB_CLASSES = ["border-success", "bg-success/10", "text-success"];
+const INACTIVE_TAB_CLASSES = ["border-border", "bg-bg", "text-text-secondary"];
+
+const BROWSER_GUIDES: Record<AddressBarBrowser, BrowserGuide> = {
+  brave: {
+    docsLabel: "Brave Help: Manage Search Engines",
+    name: "Brave",
+    settingsUrl: "brave://settings/search",
+    steps: [
+      "Select Manage Search Engines.",
+      "If flashbang appears under Inactive Shortcuts, select Activate.",
+      "Otherwise select Add and enter Search Engine: flashbang, Keyword: f (or another shortcut), and URL with %s in place of query: paste the Search URL from above.",
+      "In Search Engines, open flashbang's three-dot menu and select Make default.",
+    ],
+    docsUrl:
+      "https://support.brave.com/hc/en-us/articles/360017479752-How-do-I-set-my-default-search-engine",
+  },
+  chrome: {
+    docsLabel: "Chrome Help: Manage search engines and site shortcuts",
+    name: "Chrome",
+    settingsUrl: "chrome://settings/searchEngines",
+    steps: [
+      "Under Site search, check Inactive shortcuts. If flashbang appears, select Activate.",
+      "If it was not indexed automatically, select Add.",
+      "Enter Search engine: flashbang, Shortcut: f (or another shortcut), and URL with %s in place of query: paste the Search URL from above.",
+      "Open flashbang's More menu and select Make default.",
+    ],
+    docsUrl:
+      "https://support.google.com/chrome/answer/95426?hl=en&co=GENIE.Platform%3DDesktop",
+  },
+  edge: {
+    docsLabel: "Microsoft Support: Change your default search engine",
+    name: "Microsoft Edge",
+    settingsUrl: "edge://settings/searchEngines",
+    steps: [
+      "Edge can give bang destinations the same host-derived shortcut as flashbang, allowing the most recently used destination to take over plain searches.",
+      "Delete the auto-discovered flashbang entry.",
+      "Select Add and enter Search engine: flashbang, Shortcut: f (or another unique shortcut), and URL with %s: paste the Search URL you copied from above, not the optional Suggestions URL.",
+      "Open the new flashbang entry's menu and select Make default.",
+    ],
+    warning: {
+      label: "Important: do not only edit the auto-discovered shortcut.",
+      text: "Edge restores it from OpenSearch after restarting, so delete and re-add the entry to make the fix persist.",
+    },
+    docsUrl:
+      "https://support.microsoft.com/en-us/microsoft-edge/change-your-default-search-engine-in-microsoft-edge-cccaf51c-a4df-a43e-8036-d4d2c527a791",
+  },
+  firefox: {
+    docsLabel: "Mozilla Support: Add a custom search engine",
+    name: "Firefox",
+    settingsUrl: "about:preferences#search",
+    steps: [
+      "Under Search Shortcuts, select Add.",
+      "Enter flashbang as the Search engine name and paste the Search URL above into Engine URL.",
+      "Optional: paste the Suggestions URL above into Search suggestion API URL to enable address-bar autocomplete, then save.",
+      "Choose flashbang under Default Search Engine.",
+    ],
+    docsUrl:
+      "https://support.mozilla.org/en-US/kb/add-or-remove-search-engine-firefox#w_add-a-custom-search-engine",
+  },
+  safari: {
+    docsLabel: "Apple Support: Change Search settings",
+    name: "Safari",
+    steps: [
+      "Choose Safari > Settings, then click Search.",
+      "Safari's Search engine menu only offers its available providers and has no field for a custom URL template.",
+      "A browser extension that supports custom URL templates is required to use Flashbang as Safari's default search engine.",
+    ],
+    docsUrl: "https://support.apple.com/guide/safari/search-sfria1042d31/mac",
+  },
+};
+
+export function detectAddressBarBrowser(
+  userAgent: string,
+  isBrave = false
+): AddressBarBrowser {
+  const ua = userAgent.toLowerCase();
+  if (ua.includes("firefox") || ua.includes("fxios")) {
+    return "firefox";
+  }
+  if (ua.includes("edg/") || ua.includes("edga/") || ua.includes("edgios/")) {
+    return "edge";
+  }
+  if (isBrave || ua.includes("brave")) {
+    return "brave";
+  }
+  if (
+    ua.includes("safari") &&
+    !ua.includes("chrome") &&
+    !ua.includes("crios")
+  ) {
+    return "safari";
+  }
+  return "chrome";
+}
 
 export function setupAddressBarSheet(): void {
   const modal = $("#setup-modal");
@@ -9,11 +130,153 @@ export function setupAddressBarSheet(): void {
   const status = $("#setup-copy-status");
   const searchUrl = $<HTMLInputElement>("#setup-search-url");
   const suggestUrl = $<HTMLInputElement>("#setup-suggest-url");
+  const browserTabs = $("#setup-browser-tabs");
+  const browserName = $("#setup-browser-name");
+  const browserSteps = $("#setup-browser-steps");
+  const browserDocs = $<HTMLAnchorElement>("#setup-browser-docs");
+  let tabButtons: HTMLButtonElement[] = [];
 
   searchUrl.value = `${location.origin}?q=%s`;
   suggestUrl.value = `${location.origin}/suggest?q=%s`;
 
-  setupDialog({ closeButton, modal, openButton });
+  function showBrowserGuide(browser: AddressBarBrowser): void {
+    const guide = BROWSER_GUIDES[browser];
+    for (const button of tabButtons) {
+      const selected = button.dataset.browser === browser;
+      button.setAttribute("aria-selected", String(selected));
+      button.tabIndex = selected ? 0 : -1;
+      button.classList.remove(...ACTIVE_TAB_CLASSES, ...INACTIVE_TAB_CLASSES);
+      button.classList.add(
+        ...(selected ? ACTIVE_TAB_CLASSES : INACTIVE_TAB_CLASSES)
+      );
+    }
+    browserName.textContent = guide.name;
+    const steps = guide.steps.map((step) => el("li", "pl-1", step));
+    if (guide.settingsUrl) {
+      const settingsUrl = guide.settingsUrl;
+      const step = el("li", "pl-1");
+      const link = el(
+        "a",
+        "font-mono font-semibold text-success underline decoration-success/70 underline-offset-2 cursor-pointer hover:text-text",
+        settingsUrl
+      );
+      const linkWrap = el("span", "relative inline-flex");
+      const tooltip = el(
+        "span",
+        "absolute bottom-full left-1/2 z-10 mb-2 -translate-x-1/2 whitespace-nowrap rounded-md bg-success px-2 py-1 text-xs font-semibold text-bg shadow-lg"
+      );
+      const tooltipText = el("span", "relative z-1", "Copied to clipboard");
+      const tooltipArrow = el(
+        "span",
+        "absolute left-1/2 top-full h-2 w-2 -translate-x-1/2 -translate-y-1/2 rotate-45 bg-success"
+      );
+      tooltipArrow.setAttribute("aria-hidden", "true");
+      tooltip.append(tooltipText, tooltipArrow);
+      tooltip.role = "tooltip";
+      tooltip.hidden = true;
+      link.href = settingsUrl;
+      link.setAttribute(
+        "aria-label",
+        `Copy ${settingsUrl} to open in your address bar`
+      );
+      let tooltipTimer = 0;
+      function showTooltip(message: string): void {
+        tooltipText.textContent = message;
+        tooltip.hidden = false;
+        window.clearTimeout(tooltipTimer);
+        tooltipTimer = window.setTimeout(() => {
+          tooltip.hidden = true;
+        }, 1400);
+      }
+      link.addEventListener("click", async (event) => {
+        event.preventDefault();
+        try {
+          await copyText(settingsUrl);
+          showTooltip("Copied to clipboard");
+          status.textContent = `${settingsUrl} copied. Paste it into your address bar.`;
+        } catch {
+          showTooltip("Could not copy");
+          status.textContent = `Could not copy ${settingsUrl}`;
+        }
+      });
+      linkWrap.append(link, tooltip);
+      step.append("Open ", linkWrap, ".");
+      steps.unshift(step);
+    }
+    if (guide.warning) {
+      const warning = el("li", "pl-1");
+      warning.append(
+        el(
+          "strong",
+          "setup-browser-warning font-semibold text-amber-300",
+          guide.warning.label
+        ),
+        ` ${guide.warning.text}`
+      );
+      steps.push(warning);
+    }
+    browserSteps.replaceChildren(...steps);
+    browserDocs.href = guide.docsUrl;
+    browserDocs.textContent = guide.docsLabel;
+    browserDocs.setAttribute(
+      "aria-label",
+      `${guide.docsLabel} (opens in a new tab)`
+    );
+  }
+
+  function handleTabKeydown(
+    event: KeyboardEvent,
+    button: HTMLButtonElement
+  ): void {
+    const current = tabButtons.indexOf(button);
+    let next = current;
+    if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+      next = (current + 1) % tabButtons.length;
+    } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+      next = (current - 1 + tabButtons.length) % tabButtons.length;
+    } else if (event.key === "Home") {
+      next = 0;
+    } else if (event.key === "End") {
+      next = tabButtons.length - 1;
+    } else {
+      return;
+    }
+    event.preventDefault();
+    const nextButton = tabButtons[next];
+    showBrowserGuide(nextButton.dataset.browser as AddressBarBrowser);
+    nextButton.focus();
+  }
+
+  setupDialog({
+    closeButton,
+    modal,
+    openButton,
+    onFirstOpen() {
+      const navigatorWithBrave = navigator as Navigator & { brave?: unknown };
+      const browser = detectAddressBarBrowser(
+        navigator.userAgent,
+        Boolean(navigatorWithBrave.brave)
+      );
+      tabButtons = BROWSER_TABS.map(({ id, label }) => {
+        const button = el(
+          "button",
+          "rounded-full border px-3 py-1.5 text-xs font-semibold cursor-pointer transition-colors hover:border-text-secondary hover:bg-bg-hover hover:text-text",
+          label
+        );
+        button.type = "button";
+        button.role = "tab";
+        button.dataset.browser = id;
+        button.setAttribute("aria-controls", "setup-browser-panel");
+        button.addEventListener("click", () => showBrowserGuide(id));
+        button.addEventListener("keydown", (event) =>
+          handleTabKeydown(event, button)
+        );
+        return button;
+      });
+      browserTabs.replaceChildren(...tabButtons);
+      showBrowserGuide(browser);
+    },
+  });
 
   async function copy(
     input: HTMLInputElement,

--- a/src/ui/home/index.html
+++ b/src/ui/home/index.html
@@ -241,6 +241,7 @@
             id="setup-browser-panel"
             class="rounded-xl border border-border bg-bg-secondary p-4"
             aria-labelledby="setup-browser-heading"
+            role="tabpanel"
           >
             <h3
               id="setup-browser-heading"

--- a/src/ui/home/index.html
+++ b/src/ui/home/index.html
@@ -159,7 +159,7 @@
     >
       <div
         id="setup-card"
-        class="dialog-card relative w-full max-w-[460px] rounded-t-2xl border border-border bg-bg p-5 pb-[max(1.25rem,env(safe-area-inset-bottom))] shadow-2xl shadow-black/50 sm:rounded-2xl sm:p-6"
+        class="dialog-card relative max-h-[calc(100dvh-1rem)] w-full max-w-[520px] overflow-y-auto rounded-t-2xl border border-border bg-bg p-5 pb-[max(1.25rem,env(safe-area-inset-bottom))] shadow-2xl shadow-black/50 sm:max-h-[calc(100dvh-2rem)] sm:rounded-2xl sm:p-6"
         role="dialog"
         aria-modal="true"
         aria-labelledby="setup-title"
@@ -229,6 +229,39 @@
               </button>
             </div>
           </div>
+
+          <div
+            id="setup-browser-tabs"
+            class="flex flex-wrap gap-2"
+            role="tablist"
+            aria-label="Browser setup tabs"
+          ></div>
+
+          <section
+            id="setup-browser-panel"
+            class="rounded-xl border border-border bg-bg-secondary p-4"
+            aria-labelledby="setup-browser-heading"
+          >
+            <h3
+              id="setup-browser-heading"
+              class="mb-2 text-sm font-semibold text-text"
+            >
+              <span id="setup-browser-name">Browser</span>
+              setup
+            </h3>
+            <ol
+              id="setup-browser-steps"
+              class="mb-3 space-y-1.5 pl-5 text-sm leading-relaxed text-text-secondary list-decimal"
+            ></ol>
+            <a
+              id="setup-browser-docs"
+              href="https://support.google.com/chrome/answer/95426?hl=en"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-sm font-medium text-text underline decoration-2 decoration-text-secondary underline-offset-4 hover:text-text-hover hover:decoration-text"
+              >View official browser setup docs</a
+            >
+          </section>
         </div>
         <span
           id="setup-copy-status"

--- a/tests/address-bar-setup.test.ts
+++ b/tests/address-bar-setup.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { detectAddressBarBrowser } from "../src/ui/home/address-bar-setup";
+
+describe("address bar browser detection", () => {
+  test("detects Chromium browsers before the Chrome fallback", () => {
+    const chromium = "Mozilla/5.0 Chrome/126.0.0.0 Safari/537.36";
+
+    expect(detectAddressBarBrowser(`${chromium} Edg/126.0.0.0`)).toBe("edge");
+    expect(detectAddressBarBrowser(`${chromium} EdgA/126.0.0.0`)).toBe("edge");
+    expect(detectAddressBarBrowser(chromium, true)).toBe("brave");
+    expect(detectAddressBarBrowser(chromium)).toBe("chrome");
+  });
+
+  test("detects Firefox and Safari", () => {
+    expect(detectAddressBarBrowser("Mozilla/5.0 Firefox/128.0")).toBe(
+      "firefox"
+    );
+    expect(
+      detectAddressBarBrowser("Mozilla/5.0 Version/17.5 Safari/605.1.15")
+    ).toBe("safari");
+  });
+
+  test("detects Edge on iOS", () => {
+    expect(
+      detectAddressBarBrowser("Mozilla/5.0 EdgiOS/126.0 Mobile/15E148")
+    ).toBe("edge");
+  });
+});

--- a/tests/e2e/flashbang.e2e.ts
+++ b/tests/e2e/flashbang.e2e.ts
@@ -513,16 +513,19 @@ test("compact address-bar setup exposes browser instructions and copyable URLs",
   );
   const expectedBrowser = {
     chromium: {
+      id: "chrome",
       tab: "Chrome",
       docsHost: "support.google.com",
       settingsUrl: "chrome://settings/searchEngines",
     },
     firefox: {
+      id: "firefox",
       tab: "Firefox",
       docsHost: "support.mozilla.org",
       settingsUrl: "about:preferences#search",
     },
     webkit: {
+      id: "safari",
       tab: "Safari",
       docsHost: "support.apple.com",
       settingsUrl: null,
@@ -531,6 +534,11 @@ test("compact address-bar setup exposes browser instructions and copyable URLs",
   await expect(
     page.getByRole("tab", { name: expectedBrowser.tab, exact: true })
   ).toHaveAttribute("aria-selected", "true");
+  const browserPanel = page.getByRole("tabpanel");
+  await expect(browserPanel).toHaveAttribute(
+    "aria-labelledby",
+    `setup-browser-tab-${expectedBrowser.id}`
+  );
   await expect(page.locator("#setup-browser-steps li")).not.toHaveCount(0);
   await expect(page.locator("#setup-browser-docs")).toHaveAttribute(
     "href",
@@ -553,6 +561,10 @@ test("compact address-bar setup exposes browser instructions and copyable URLs",
     "aria-selected",
     "true"
   );
+  await expect(browserPanel).toHaveAttribute(
+    "aria-labelledby",
+    "setup-browser-tab-edge"
+  );
   await expect(page.locator("#setup-browser-steps a")).toHaveAttribute(
     "href",
     "edge://settings/searchEngines"
@@ -566,6 +578,10 @@ test("compact address-bar setup exposes browser instructions and copyable URLs",
   await expect(page.getByRole("tab", { name: "Firefox" })).toHaveAttribute(
     "aria-selected",
     "true"
+  );
+  await expect(browserPanel).toHaveAttribute(
+    "aria-labelledby",
+    "setup-browser-tab-firefox"
   );
 
   const cardBox = await page.locator("#setup-card").boundingBox();

--- a/tests/e2e/flashbang.e2e.ts
+++ b/tests/e2e/flashbang.e2e.ts
@@ -481,7 +481,10 @@ test("homepage bang finder supports suffix bang and snap selection", async ({
   await expect(input).toHaveValue("Hello World");
 });
 
-test("compact address-bar setup exposes copyable URLs", async ({ page }) => {
+test("compact address-bar setup exposes browser instructions and copyable URLs", async ({
+  browserName,
+  page,
+}) => {
   await page.addInitScript(() => {
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
@@ -507,6 +510,62 @@ test("compact address-bar setup exposes copyable URLs", async ({ page }) => {
   );
   await expect(page.locator("#setup-suggest-url")).toHaveValue(
     `${new URL(page.url()).origin}/suggest?q=%s`
+  );
+  const expectedBrowser = {
+    chromium: {
+      tab: "Chrome",
+      docsHost: "support.google.com",
+      settingsUrl: "chrome://settings/searchEngines",
+    },
+    firefox: {
+      tab: "Firefox",
+      docsHost: "support.mozilla.org",
+      settingsUrl: "about:preferences#search",
+    },
+    webkit: {
+      tab: "Safari",
+      docsHost: "support.apple.com",
+      settingsUrl: null,
+    },
+  }[browserName];
+  await expect(
+    page.getByRole("tab", { name: expectedBrowser.tab, exact: true })
+  ).toHaveAttribute("aria-selected", "true");
+  await expect(page.locator("#setup-browser-steps li")).not.toHaveCount(0);
+  await expect(page.locator("#setup-browser-docs")).toHaveAttribute(
+    "href",
+    new RegExp(`^https://${expectedBrowser.docsHost.replaceAll(".", "\\.")}/`)
+  );
+  const settingsLink = page.locator("#setup-browser-steps a");
+  if (expectedBrowser.settingsUrl) {
+    await expect(settingsLink).toHaveAttribute(
+      "href",
+      expectedBrowser.settingsUrl
+    );
+    await settingsLink.click();
+    await expect(page.getByRole("tooltip")).toBeVisible();
+  } else {
+    await expect(settingsLink).toHaveCount(0);
+  }
+
+  await page.getByRole("tab", { name: "Edge" }).click();
+  await expect(page.getByRole("tab", { name: "Edge" })).toHaveAttribute(
+    "aria-selected",
+    "true"
+  );
+  await expect(page.locator("#setup-browser-steps a")).toHaveAttribute(
+    "href",
+    "edge://settings/searchEngines"
+  );
+  await expect(page.locator(".setup-browser-warning")).toBeVisible();
+  await expect(page.locator("#setup-browser-docs")).toHaveAttribute(
+    "href",
+    /^https:\/\/support\.microsoft\.com\//
+  );
+  await page.getByRole("tab", { name: "Edge" }).press("ArrowRight");
+  await expect(page.getByRole("tab", { name: "Firefox" })).toHaveAttribute(
+    "aria-selected",
+    "true"
   );
 
   const cardBox = await page.locator("#setup-card").boundingBox();


### PR DESCRIPTION
## Summary
- add browser-detected setup tabs for Chrome, Edge, Firefox, Brave, and Safari
- document official settings paths and Flashbang-specific Edge behavior
- add accessible tab navigation, copyable internal settings URLs, and responsive modal styling
- cover browser detection and modal behavior

## Testing
- bun run check
- bun run typecheck
- bun test
- bun run build
- bun run test:e2e --grep "compact address-bar setup"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added browser-specific address bar setup instructions for Chromium, Brave, Edge, Firefox, and Safari.
  * Added browser tabs for switching between setup guides.
  * Added copyable browser settings URLs with confirmation feedback.
  * Added keyboard navigation for browser tabs.
  * Added browser warnings and links to official setup documentation.

* **Bug Fixes**
  * Improved address bar setup modal layout with responsive sizing and scrolling.

* **Tests**
  * Added coverage for browser detection and end-to-end setup guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->