### PR TITLE
feat: add configurable shortcut syntax

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -75,6 +75,7 @@ flashbang/
 │   │   ├── raw-url.ts         # Raw URL pathname and origin parsing
 │   │   ├── snap-target.ts     # Alternate snap target validation and compilation
 │   │   ├── suggest-cookie.ts  # Unified suggestion cookie codec
+│   │   ├── trigger-prefix.ts  # Configurable bang/snap prefix codec
 │   │   ├── template.ts        # Bang URL template expansion
 │   │   └── trie.ts            # Radix trie lookup
 │   ├── generated/             # Output of codegen (gitignored, generated from data/bangs.json)
@@ -94,6 +95,7 @@ flashbang/
 │       ├── app.ts             # Initialization & orchestration
 │       ├── bang-catalog.ts    # Shared normalized bang metadata and bounded search
 │       ├── bang-meta.ts       # Packed metadata validation and cursor decoder
+│       ├── firefox-suggest.ts # Shared Firefox detection and suggestion URL builder
 │       ├── suggest-provider.ts # Suggestion provider feature availability
 │       ├── bench/
 │       │   ├── index.html     # Benchmark page
@@ -109,6 +111,7 @@ flashbang/
 │       │   ├── default-bang.ts # Default bang preview and persistence
 │       │   ├── firefox.ts     # Firefox suggestion-provider picker
 │       │   ├── providers.ts   # Suggestion and lucky provider controls
+│       │   ├── syntax.ts      # Bang/snap prefix selection and persistence
 │       │   ├── transfer.ts    # Settings import and export
 │       │   ├── write.ts       # Serialized writes, validation, and save status
 │       │   └── custom-bangs.ts # Custom bang list and add/edit form
@@ -213,7 +216,7 @@ The generated data is split by consumer. The Service Worker loads the regular lo
 
 User-created simple bangs use a URL containing `{}`. Capture bangs instead pair a regular expression with `$1`, `$2`, and later placeholders in the URL template. `src/shared/capture-template.ts` validates pattern and template bounds, rejects unsafe constructs, prevents captures from changing the URL origin, and compiles accepted records once when Service Worker settings load. Capture substitutions support percent, plus-space, and raw encoding.
 
-Kagi `ad` metadata and the custom-bang **Snap target** field provide an alternate domain or path for `@trigger` searches without changing normal `!trigger` behavior. `src/shared/snap-target.ts` validates and compiles targets into a site filter plus bare-snap origin. Codegen emits only non-redundant built-in overrides; custom targets are attached to their precompiled IndexedDB entries.
+Kagi `ad` metadata and the custom-bang **Snap target** field provide an alternate domain or path for snap searches without changing normal bang behavior. Bang and snap prefixes are distinct user settings selected from `!`, `@`, `$`, `:`, `;`, and `~`; defaults are `!` and `@`. `src/shared/trigger-prefix.ts` validates and compactly serializes those settings, while `src/shared/snap-target.ts` validates and compiles targets into a site filter plus bare-snap origin. Codegen emits only non-redundant built-in overrides; custom targets are attached to their precompiled IndexedDB entries.
 
 Custom bangs are stored in the `custom-bangs` IndexedDB object store. The UI supports add, edit, atomic trigger rename, remove, import, and export. After a mutation, `notifySW("invalidate")` clears the Service Worker's cached settings so regex and snap metadata are recompiled on the next read. The suggestion cookie contains custom trigger names for autocomplete, not full custom definitions.
 
@@ -264,7 +267,7 @@ The Service Worker tracks bang usage to personalize suggestion ordering. The flo
 
 The in-memory state (`frecencyCounts` plus `topFrecency` in `idb.ts`) is loaded from IndexedDB once and kept for the Service Worker lifetime. `invalidateCache()` clears only redirect settings and the shared database connection; loaded frecency and pending persistence remain intact. Browser benchmark mode suppresses these side effects only for the requesting benchmark client.
 
-**Browser cookie behavior**: Chromium-based browsers (Chrome, Edge, Arc) send cookies with suggest requests when the site is the default search engine. Firefox-based browsers (Firefox, Zen, LibreWolf) intentionally withhold cookies from OpenSearch suggest requests as a privacy decision ([bug 1624457](https://bugzilla.mozilla.org/show_bug.cgi?id=1624457)). The settings UI therefore provides a copyable Firefox suggestion URL with an explicit provider. Cookie-backed custom trigger suggestions and frecency are unavailable on those requests; redirect behavior is unaffected.
+**Browser cookie behavior**: Chromium-based browsers (Chrome, Edge, Arc) send cookies with suggest requests when the site is the default search engine. Firefox-based browsers (Firefox, Zen, LibreWolf) intentionally withhold cookies from OpenSearch suggest requests as a privacy decision ([bug 1624457](https://bugzilla.mozilla.org/show_bug.cgi?id=1624457)). The settings UI therefore provides a copyable Firefox suggestion URL with an explicit provider and bang/snap prefixes. Cookie-backed custom trigger suggestions and frecency are unavailable on those requests; redirect behavior is unaffected.
 
 ## Dev server
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -267,7 +267,7 @@ The Service Worker tracks bang usage to personalize suggestion ordering. The flo
 
 The in-memory state (`frecencyCounts` plus `topFrecency` in `idb.ts`) is loaded from IndexedDB once and kept for the Service Worker lifetime. `invalidateCache()` clears only redirect settings and the shared database connection; loaded frecency and pending persistence remain intact. Browser benchmark mode suppresses these side effects only for the requesting benchmark client.
 
-**Browser cookie behavior**: Chromium-based browsers (Chrome, Edge, Arc) send cookies with suggest requests when the site is the default search engine. Firefox-based browsers (Firefox, Zen, LibreWolf) intentionally withhold cookies from OpenSearch suggest requests as a privacy decision ([bug 1624457](https://bugzilla.mozilla.org/show_bug.cgi?id=1624457)). The settings UI therefore provides a copyable Firefox suggestion URL with an explicit provider and bang/snap prefixes. Cookie-backed custom trigger suggestions and frecency are unavailable on those requests; redirect behavior is unaffected.
+**Browser cookie behavior**: Chromium-based browsers (Chrome, Edge, Arc) send cookies with suggest requests when the site is the default search engine. Firefox-based browsers (Firefox, Zen, LibreWolf) intentionally withhold cookies from OpenSearch suggest requests as a privacy decision ([bug 1624457](https://bugzilla.mozilla.org/show_bug.cgi?id=1624457)). The settings UI therefore provides a copyable Firefox suggestion URL with an explicit provider; it adds `bp` and `np` only for non-default syntax and omits the default `!`/`@` pair. Cookie-backed custom trigger suggestions and frecency are unavailable on those requests; redirect behavior is unaffected.
 
 ## Dev server
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ COPY --from=builder /app/src/shared/raw-query.ts src/shared/raw-query.ts
 COPY --from=builder /app/src/shared/raw-url.ts src/shared/raw-url.ts
 COPY --from=builder /app/src/shared/suggest-cookie.ts src/shared/suggest-cookie.ts
 COPY --from=builder /app/src/shared/template.ts src/shared/template.ts
+COPY --from=builder /app/src/shared/trigger-prefix.ts src/shared/trigger-prefix.ts
 COPY --from=builder /app/src/generated/bangs-trie.js src/generated/bangs-trie.js
 
 USER bun

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ All three support bangs natively — but every query still round-trips through t
 - **Search suggestions** — The only bang tool with bang-aware autocomplete in your browser's native address bar. Type `!y` and the browser itself suggests `!yt` (YouTube), `!ya` (Yandex), `!yf` (Yahoo Finance) — ranked by a combination of global popularity and your personal usage frequency. Regular queries can use Google, DuckDuckGo, Bing, Brave, Yahoo, Ecosia, Kagi, Qwant, Startpage, Yandex, or Baidu. Self-hosted deployments can explicitly opt into custom providers. Both are unified through a single `/suggest` endpoint that plugs into your browser's built-in suggestion UI. Firefox-based browsers also render bang descriptions, site names, and favicons inline in the dropdown via `google:suggestdetail`. See [Browser quirks](#browser-quirks) for rendering and cookie differences across browsers
 - **Frecency** — The Service Worker tracks which bangs and snaps you use and how often, entirely in-memory on the redirect path. Your most-used triggers are promoted in autocomplete suggestions so they surface first. Compact snapshots are persisted to IndexedDB across Service Worker restarts. Suggestion personalization is available in Chromium-based browsers; it is not available in Firefox-based browsers — see [Browser quirks](#browser-quirks)
 - **Snaps** — Type `@trigger query` to search your default engine with results restricted to that trigger's domain via `site:`. For example, `@w quantum` searches Google for `quantum site:en.wikipedia.org`. Works in prefix (`@w quantum`) and suffix (`quantum @w`) positions. A bare snap (`@w`) redirects to the trigger's homepage. Snaps reuse bang triggers; entries without a resolvable web domain, such as the internal `settings` shortcut, fall back to a normal search
-- **Feeling Lucky** — Prefix a query with `\`, or add a bare `!` before or after it, to skip the results page and jump straight to the first result. The default mode matches Google, DuckDuckGo, or Kagi when one of those is your default engine, and falls back to DuckDuckGo for other engines. You can also select a provider, use a custom URL, or disable it entirely
+- **Feeling Lucky** — Prefix a query with `\`, or add the selected bang prefix before or after it, to skip the results page and jump straight to the first result. The bang prefix defaults to `!`; selecting another prefix replaces those bare `!` forms, while `\` remains available. The default mode matches Google, DuckDuckGo, or Kagi when one of those is your default engine, and falls back to DuckDuckGo for other engines. You can also select a provider, use a custom URL, or disable it entirely
 - **OpenSearch** — Browsers auto-discover Flashbang as a search engine via `/opensearch.xml`, including the suggestions endpoint. The XML is dynamically generated at request time using the current origin, so it works out of the box on any self-hosted domain or `localhost` — no hardcoded URLs to change
 
 ## Configurable syntax
@@ -98,13 +98,13 @@ The suggestion endpoint accepts cookie-independent query parameters for the sugg
 
 `bp` and `np` must be supplied together, must differ, and each accepts `!`, `@`, `$`, `:`, `;`, or `~`. Invalid pairs safely fall back to cookie or default settings. Provider values are:
 
-```
+```text
 google, ddg, bing, brave, yahoo, ecosia, kagi, qwant, startpage, yandex, baidu, none
 ```
 
 Example Firefox suggestion URL with provider and syntax overrides:
 
-```
+```text
 https://flashbang-dyr.pages.dev/suggest?q=%s&sp=ddg&bp=%24&np=~
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ All three support bangs natively — but every query still round-trips through t
 
 ### Privacy
 
-> Core redirects never leave your machine — the Service Worker handles them offline with no server involved. Search suggestions are completely optional and go through our server when enabled on the hosted version. One same-site cookie (`suggest`) stores your configured suggestion provider, default bang, optional custom suggestion URL, custom bang trigger names, and compact top bang usage counts so the server can proxy and personalize suggestions. The frecency section contains only bang triggers and hit counts (e.g. `g:50.yt:30`), never query content. No accounts, no sessions, no personal data. There is no tracking or analytics — we don't know what you search or what bangs you use. Cloudflare Pages exposes basic request counts in its dashboard as a platform feature we did not opt into and cannot disable. It contains no query content or personally identifiable information.
+> Core redirects never leave your machine — the Service Worker handles them offline with no server involved. Search suggestions are completely optional and go through our server when enabled on the hosted version. One same-site cookie (`suggest`) stores your configured suggestion provider, default bang, selected bang/snap prefixes, optional custom suggestion URL, custom bang trigger names, and compact top bang usage counts so the server can proxy and personalize suggestions. The frecency section contains only bang triggers and hit counts (e.g. `g:50.yt:30`), never query content. No accounts, no sessions, no personal data. There is no tracking or analytics — we don't know what you search or what bangs you use. Cloudflare Pages exposes basic request counts in its dashboard as a platform feature we did not opt into and cannot disable. It contains no query content or personally identifiable information.
 >
 > If you'd rather not trust our server at all, Flashbang is fully self-hostable. Deploy to Cloudflare Pages/Railway in minutes or `docker run` it on any VPS — a single command gets you a fully private instance. See [Setup](#setup-as-search-engine) for details.
 
@@ -31,11 +31,16 @@ All three support bangs natively — but every query still round-trips through t
 - **Private** — No analytics, no tracking. All data stays on your device for the core feature - redirects
 - **14,000+ bangs** — Merged from DuckDuckGo, Kagi, and custom sources. Updated daily via automated CI
 - **Custom bangs** — Add your own bangs through the settings UI. They take priority over built-ins
+- **Configurable syntax** — Choose distinct bang and snap prefixes from `!`, `@`, `$`, `:`, `;`, and `~`. Defaults are `!` for bangs and `@` for snaps. The selected bang prefix also controls bare Feeling Lucky forms; leading `\query` always remains available
 - **Search suggestions** — The only bang tool with bang-aware autocomplete in your browser's native address bar. Type `!y` and the browser itself suggests `!yt` (YouTube), `!ya` (Yandex), `!yf` (Yahoo Finance) — ranked by a combination of global popularity and your personal usage frequency. Regular queries can use Google, DuckDuckGo, Bing, Brave, Yahoo, Ecosia, Kagi, Qwant, Startpage, Yandex, or Baidu. Self-hosted deployments can explicitly opt into custom providers. Both are unified through a single `/suggest` endpoint that plugs into your browser's built-in suggestion UI. Firefox-based browsers also render bang descriptions, site names, and favicons inline in the dropdown via `google:suggestdetail`. See [Browser quirks](#browser-quirks) for rendering and cookie differences across browsers
 - **Frecency** — The Service Worker tracks which bangs and snaps you use and how often, entirely in-memory on the redirect path. Your most-used triggers are promoted in autocomplete suggestions so they surface first. Compact snapshots are persisted to IndexedDB across Service Worker restarts. Suggestion personalization is available in Chromium-based browsers; it is not available in Firefox-based browsers — see [Browser quirks](#browser-quirks)
 - **Snaps** — Type `@trigger query` to search your default engine with results restricted to that trigger's domain via `site:`. For example, `@w quantum` searches Google for `quantum site:en.wikipedia.org`. Works in prefix (`@w quantum`) and suffix (`quantum @w`) positions. A bare snap (`@w`) redirects to the trigger's homepage. Snaps reuse bang triggers; entries without a resolvable web domain, such as the internal `settings` shortcut, fall back to a normal search
 - **Feeling Lucky** — Prefix a query with `\`, or add a bare `!` before or after it, to skip the results page and jump straight to the first result. The default mode matches Google, DuckDuckGo, or Kagi when one of those is your default engine, and falls back to DuckDuckGo for other engines. You can also select a provider, use a custom URL, or disable it entirely
 - **OpenSearch** — Browsers auto-discover Flashbang as a search engine via `/opensearch.xml`, including the suggestions endpoint. The XML is dynamically generated at request time using the current origin, so it works out of the box on any self-hosted domain or `localhost` — no hardcoded URLs to change
+
+## Configurable syntax
+
+Settings lets you select different prefixes for bangs and snaps from `!`, `@`, `$`, `:`, `;`, and `~`. Changing a prefix replaces that syntax rather than adding an alias. For example, with `$` for bangs and `~` for snaps, use `$gh react`, `react $gh`, `~w quantum`, and `quantum ~w`; `!gh` and `@w` become ordinary search text. The examples below use the default `!` and `@` prefixes.
 
 ## Bang syntax
 
@@ -52,7 +57,7 @@ If the query is just a bang with no search term (e.g. `!g`), Flashbang redirects
 
 ## Snap syntax
 
-Snaps use `@` instead of `!` to perform a **site-restricted search** — your query goes to your default search engine with `site:domain` appended. Any bang trigger with a resolvable web domain works as a snap. All snaps are case-insensitive.
+By default, snaps use `@` instead of `!` to perform a **site-restricted search** — your query goes to your default search engine with `site:domain` appended. Any bang trigger with a resolvable web domain works as a snap. All snaps are case-insensitive.
 
 | Format      | Example      | Result                                                    |
 | ----------- | ------------ | --------------------------------------------------------- |
@@ -64,7 +69,7 @@ If a query contains both a bang (`!`) and a snap (`@`), the bang takes precedenc
 
 ### Feeling Lucky
 
-Skip the search results page and go directly to the first result. Three syntax options:
+Skip the search results page and go directly to the first result. The table uses the default bang prefix; if you change it, the leading/trailing bare marker changes with it. Leading backslash remains fixed.
 
 | Format       | Example     | Result                     |
 | ------------ | ----------- | -------------------------- |
@@ -85,19 +90,25 @@ The redirect destination depends on your lucky provider (configurable in setting
 
 ### Suggestion URL parameters
 
-The suggestion endpoint accepts an optional `sp` (suggestion provider) query parameter to choose which search engine provides autocomplete results, without relying on cookies:
+The suggestion endpoint accepts cookie-independent query parameters for the suggestion provider and shortcut syntax:
+
+- `sp` selects the suggestion provider
+- `bp` selects the bang prefix
+- `np` selects the snap prefix
+
+`bp` and `np` must be supplied together, must differ, and each accepts `!`, `@`, `$`, `:`, `;`, or `~`. Invalid pairs safely fall back to cookie or default settings. Provider values are:
 
 ```
 google, ddg, bing, brave, yahoo, ecosia, kagi, qwant, startpage, yandex, baidu, none
 ```
 
-Example suggestion URL with a provider override:
+Example Firefox suggestion URL with provider and syntax overrides:
 
 ```
-https://flashbang-dyr.pages.dev/suggest?q=%s&sp=ddg
+https://flashbang-dyr.pages.dev/suggest?q=%s&sp=ddg&bp=%24&np=~
 ```
 
-**Why this exists:** in Chromium-based browsers, cookies are sent with suggest requests and settings configured in the UI are picked up automatically — `sp` is rarely needed. In Firefox-based browsers, cookies are withheld and `sp` is the only way to pick a provider. See [Browser quirks](#browser-quirks) for details.
+**Why this exists:** in Chromium-based browsers, cookies are sent with suggest requests and settings configured in the UI are picked up automatically, so these overrides are rarely needed. Firefox-based browsers withhold cookies; the settings UI therefore generates a copyable URL containing `sp`, and adds `bp` plus `np` when the selected syntax differs from the default `!`/`@` pair. See [Browser quirks](#browser-quirks) for details.
 
 ### Use the hosted version
 
@@ -124,7 +135,7 @@ These apply equally to the hosted version and any self-hosted instance — worth
 
   **Important:** _editing_ the auto-discovered entry's Shortcut doesn't persist — Edge re-derives it from `/opensearch.xml` on restart and reverts to the host. The delete-and-readd step is what makes the fix stick, because a manually-added entry is independent of the discovery XML.
 
-- **Firefox / Zen / LibreWolf — no frecency, no custom bangs in suggestions.** Firefox-based browsers intentionally [withhold cookies from OpenSearch suggest requests](https://bugzilla.mozilla.org/show_bug.cgi?id=1624457) as a privacy measure. Flashbang's suggestion context (configured provider, custom bang trigger names, and frecency data) is carried by the unified `suggest` cookie, so those features are unavailable on these requests — suggestions fall back to Google with default popularity ranking. To pick a different suggestion provider, register the suggestion URL with the `sp` parameter (e.g. `…/suggest?q=%s&sp=ddg`) — see [Suggestion URL parameters](#suggestion-url-parameters).
+- **Firefox / Zen / LibreWolf — no frecency, no custom bangs in suggestions.** Firefox-based browsers intentionally [withhold cookies from OpenSearch suggest requests](https://bugzilla.mozilla.org/show_bug.cgi?id=1624457) as a privacy measure. Flashbang's custom bang trigger names and frecency data are carried by the unified `suggest` cookie, so those features remain unavailable on these requests. Provider and bang/snap prefix settings can be embedded directly with `sp`, `bp`, and `np`; the settings UI generates the complete URL — see [Suggestion URL parameters](#suggestion-url-parameters).
 
 - **Chromium — plain-text suggestions only.** Chrome, Edge, Arc, and other Chromium-based browsers don't render rich suggestion details (descriptions, favicons, entity images) for search-type suggestions from custom search engines; they're shown as plain text. Firefox-based browsers render the rich data passed through `google:suggestdetail`. This is a Chromium limitation, not flashbang's.
 
@@ -195,7 +206,8 @@ The settings page has a copy button that gives you the exact search URL template
 
 Open the settings modal from the gear icon on the home page, or type **`!settings`** in the address bar to jump there directly. Type **`!`** on its own to quickly access the home page.
 
-- **Default bang** — The built-in bang used when no `!` is in the query. Defaults to `g` (Google). Change it to `ddg`, `b`, or any other built-in trigger
+- **Shortcut syntax** — Choose distinct bang and snap prefixes from `!`, `@`, `$`, `:`, `;`, and `~`. Defaults are `!` and `@`
+- **Default bang** — The built-in bang used when no selected bang prefix is in the query. Defaults to `g` (Google). Change it to `ddg`, `b`, or any other built-in trigger
 - **Feeling Lucky** — Choose how lucky redirects resolve: Default (match Google, DuckDuckGo, or Kagi when selected as the default bang, otherwise fall back to DuckDuckGo), Google, DuckDuckGo, Kagi, Custom (your own URL template with `{}` as query placeholder), or Disabled
 - **Search suggestions** — Choose the source for address bar autocomplete: Default (match a supported default bang, otherwise return no regular-query suggestions), Google, DuckDuckGo, Bing, Brave, Yahoo, Ecosia, Kagi, Qwant, Startpage, Yandex, Baidu, Custom (self-hosted deployments with `ALLOW_UNSAFE_CUSTOM_SUGGEST_URLS=true` only), or None
 - **Custom bangs** — Add bangs with a trigger, name, and URL template (use `{}` as the query placeholder). Advanced bangs can match the query with a regular expression, substitute `$1`, `$2`, etc., and set a separate domain or path for `@snap` searches. Custom bangs override built-in ones
@@ -210,7 +222,7 @@ An optional snap target such as `docs.example.com/api` makes `@mybang query` sea
 
 ## How it works
 
-When you type `!gh react` in the address bar, the Service Worker intercepts the request before it reaches the network. It parses the bang trigger, looks it up in the bang map (checking custom bangs first, then built-ins), and responds with a 302 redirect. Snaps (`@trigger`) work the same way — the Service Worker resolves the trigger's domain and redirects to your default search engine with `site:domain` appended. If no bang or snap is found, your default search engine is used.
+When you type `!gh react` (or the equivalent with your selected bang prefix) in the address bar, the Service Worker intercepts the request before it reaches the network. It parses the bang trigger, looks it up in the bang map (checking custom bangs first, then built-ins), and responds with a 302 redirect. Snaps work the same way with their separately selected prefix — the Service Worker resolves the trigger's domain and redirects to your default search engine with `site:domain` appended. If no bang or snap is found, your default search engine is used.
 
 See [DEVELOPMENT.md](DEVELOPMENT.md) for build pipeline and project structure details.
 

--- a/scripts/profile.ts
+++ b/scripts/profile.ts
@@ -4,6 +4,7 @@ import { dirname, isAbsolute, join, resolve } from "node:path";
 import { compileCaptureUrl } from "../src/shared/capture-template";
 import { readPathname } from "../src/shared/raw-url";
 import { compileSnapTarget } from "../src/shared/snap-target";
+import { TRIGGER_PREFIXES } from "../src/shared/trigger-prefix";
 import {
   EDGE_CHILD_INDEX,
   EDGE_STRIDE,
@@ -716,7 +717,9 @@ console.log(
 
 separator("5. FULL REDIRECT PIPELINE");
 
-const { redirectRaw, redirectUrl } = await import("../src/sw/redirect");
+const { compileTriggerSyntax, redirectRaw, redirectUrl } = await import(
+  "../src/sw/redirect"
+);
 
 const profileCaptureUrl = compileCaptureUrl(
   "https://translate.example/$1/$2",
@@ -733,6 +736,10 @@ const settings = {
     docs: ["https://search.example.com?q=", "", profileSnapTarget] as const,
   },
 } satisfies RedirectSettings;
+const configuredSyntaxSettings: RedirectSettings = {
+  ...settings,
+  syntax: compileTriggerSyntax("$", "~"),
+};
 
 const queries = [
   { label: "Prefix bang", raw: "!g+kittens" },
@@ -836,6 +843,79 @@ const messageStats = bench(
 
 console.log(
   `SW message redirect path (redirectUrl): ${fmt(messageStats.p50)} median, ${fmt(messageStats.p90)} p90`
+);
+
+console.log("\nConfigured syntax A/B ($ bangs, ~ snaps):");
+for (const sample of [
+  {
+    label: "Prefix bang",
+    defaultRaw: "%21g+kittens",
+    customRaw: "%24g+kittens",
+  },
+  {
+    label: "Suffix bang",
+    defaultRaw: "kittens+%21g",
+    customRaw: "kittens+%24g",
+  },
+  { label: "Prefix snap", defaultRaw: "%40g+kittens", customRaw: "~g+kittens" },
+  { label: "Suffix snap", defaultRaw: "kittens+%40g", customRaw: "kittens+~g" },
+  { label: "No trigger", defaultRaw: "kittens", customRaw: "kittens" },
+]) {
+  const defaultStats = bench(REDIRECT_ITERS, () => {
+    redirectRaw(sample.defaultRaw, settings);
+  });
+  const customStats = bench(REDIRECT_ITERS, () => {
+    redirectRaw(sample.customRaw, configuredSyntaxSettings);
+  });
+  const ratio = customStats.p50 / defaultStats.p50;
+  console.log(
+    `  ${sample.label.padEnd(14)} default ${fmt(defaultStats.p50).padStart(8)}  configured ${fmt(customStats.p50).padStart(8)}  ${ratio.toFixed(2)}×`
+  );
+}
+
+const encodedTriggerPrefixes = [
+  "%21",
+  "%40",
+  "%24",
+  "%3A",
+  "%3B",
+  "%7E",
+] as const;
+const PAIR_ITERS = iterations(100_000);
+const baselinePairStats = bench(PAIR_ITERS, (i) => {
+  redirectRaw(i & 1 ? "%40g+kittens" : "%21g+kittens", settings);
+});
+let fastestPair = Number.POSITIVE_INFINITY;
+let slowestPair = 0;
+let slowestPairLabel = "";
+let pairCount = 0;
+for (let bangIndex = 0; bangIndex < TRIGGER_PREFIXES.length; bangIndex++) {
+  for (let snapIndex = 0; snapIndex < TRIGGER_PREFIXES.length; snapIndex++) {
+    if (bangIndex === snapIndex) {
+      continue;
+    }
+    const pairSettings: RedirectSettings = {
+      ...settings,
+      syntax: compileTriggerSyntax(
+        TRIGGER_PREFIXES[bangIndex],
+        TRIGGER_PREFIXES[snapIndex]
+      ),
+    };
+    const bangRaw = `${encodedTriggerPrefixes[bangIndex]}g+kittens`;
+    const snapRaw = `${encodedTriggerPrefixes[snapIndex]}g+kittens`;
+    const pairStats = bench(PAIR_ITERS, (i) => {
+      redirectRaw(i & 1 ? snapRaw : bangRaw, pairSettings);
+    });
+    fastestPair = Math.min(fastestPair, pairStats.p50);
+    if (pairStats.p50 > slowestPair) {
+      slowestPair = pairStats.p50;
+      slowestPairLabel = `${TRIGGER_PREFIXES[bangIndex]}/${TRIGGER_PREFIXES[snapIndex]}`;
+    }
+    pairCount++;
+  }
+}
+console.log(
+  `  All ${pairCount} pairs   default ${fmt(baselinePairStats.p50).padStart(8)}  range ${fmt(fastestPair)}..${fmt(slowestPair)}  worst ${slowestPairLabel} ${(slowestPair / baselinePairStats.p50).toFixed(2)}×`
 );
 
 separator("5b. REDIRECT FIXUP ISOLATION");

--- a/src/server/handlers.ts
+++ b/src/server/handlers.ts
@@ -1,10 +1,18 @@
 import { canonicalizePublicOrigin, opensearch } from "../opensearch";
 import { COOKIE_MAX_AGE_S } from "../shared/constants";
-import { readTwoQueryParams } from "../shared/raw-query";
+import { readSuggestQueryParams } from "../shared/raw-query";
 import { readOrigin } from "../shared/raw-url";
 import {
+  DEFAULT_BANG_PREFIX,
+  DEFAULT_SNAP_PREFIX,
+} from "../shared/trigger-prefix";
+import {
+  type PartialBang,
+  parseBangSettingsFromRequestWithCleanup,
   parsePartialBang,
+  parseSettingsFromRawUrl,
   parseSettingsFromRawUrlWithCleanup,
+  type SuggestSettings,
   suggest,
 } from "../suggest";
 
@@ -37,7 +45,7 @@ export function handleSuggestRequest(
   environment: SuggestEnvironment = runtimeEnvironment()
 ): Promise<Response> {
   const rawUrl = request.url;
-  const [q, sp] = readTwoQueryParams(rawUrl, "q", "sp");
+  const [q, sp, bp, np] = readSuggestQueryParams(rawUrl);
   if (!q) {
     return Promise.resolve(
       new Response(MISSING_Q, {
@@ -46,9 +54,42 @@ export function handleSuggestRequest(
       })
     );
   }
-  const bang = parsePartialBang(q);
-  const { settings, rewrittenSuggestCookie } =
-    parseSettingsFromRawUrlWithCleanup(rawUrl, request, sp, bang !== null);
+  const defaultBang = parsePartialBang(q);
+  let settings: SuggestSettings;
+  let rewrittenSuggestCookie: string | null;
+  let bang: PartialBang | null;
+  if (defaultBang) {
+    ({ settings, rewrittenSuggestCookie } = parseSettingsFromRawUrlWithCleanup(
+      rawUrl,
+      request,
+      sp,
+      true,
+      bp,
+      np
+    ));
+    bang =
+      settings.bangPrefix === DEFAULT_BANG_PREFIX &&
+      settings.snapPrefix === DEFAULT_SNAP_PREFIX
+        ? defaultBang
+        : parsePartialBang(q, settings.bangPrefix, settings.snapPrefix);
+  } else {
+    const coreSettings = parseSettingsFromRawUrl(
+      rawUrl,
+      request,
+      sp,
+      false,
+      bp,
+      np
+    );
+    bang =
+      coreSettings.bangPrefix === DEFAULT_BANG_PREFIX &&
+      coreSettings.snapPrefix === DEFAULT_SNAP_PREFIX
+        ? defaultBang
+        : parsePartialBang(q, coreSettings.bangPrefix, coreSettings.snapPrefix);
+    ({ settings, rewrittenSuggestCookie } = bang
+      ? parseBangSettingsFromRequestWithCleanup(request, coreSettings)
+      : { settings: coreSettings, rewrittenSuggestCookie: null });
+  }
   const allowUnsafeCustomUrls =
     environment.ALLOW_UNSAFE_CUSTOM_SUGGEST_URLS === "true";
   return suggest(q, settings, bang, allowUnsafeCustomUrls).then((response) => {

--- a/src/shared/custom-trigger.ts
+++ b/src/shared/custom-trigger.ts
@@ -6,7 +6,7 @@ const RESERVED_CUSTOM_TRIGGERS = new Set([
   "prototype",
   "settings",
 ]);
-const ENCODED_TRIGGER_SEPARATOR = /%(?:20|21|40)/i;
+const ENCODED_TRIGGER_SEPARATOR = /%(?:20|21|24|3a|3b|40|7e)/i;
 
 export function validateCustomTrigger(trigger: string): string | null {
   if (!trigger) {
@@ -18,14 +18,14 @@ export function validateCustomTrigger(trigger: string): string | null {
   if (/\s/u.test(trigger)) {
     return "Shortcut cannot contain whitespace";
   }
-  if (trigger.includes("!") || trigger.includes("@") || trigger.includes("+")) {
-    return "Shortcut cannot contain !, @, or +";
+  if (/[!@$:;~+]/u.test(trigger)) {
+    return "Shortcut cannot contain trigger prefixes (!, @, $, :, ;, ~) or +";
   }
-  if (trigger.includes(",") || trigger.includes(":")) {
-    return "Shortcut cannot contain comma or colon";
+  if (trigger.includes(",")) {
+    return "Shortcut cannot contain comma";
   }
   if (ENCODED_TRIGGER_SEPARATOR.test(trigger)) {
-    return "Shortcut cannot contain encoded separators (%20, %21, or %40)";
+    return "Shortcut cannot contain encoded spaces or trigger prefixes";
   }
   if (RESERVED_CUSTOM_TRIGGERS.has(trigger.toLowerCase())) {
     return `"${trigger}" is a reserved shortcut`;

--- a/src/shared/raw-query.ts
+++ b/src/shared/raw-query.ts
@@ -148,3 +148,76 @@ export function readTwoQueryParams(
 
   return [a, b];
 }
+
+export function readSuggestQueryParams(
+  rawUrl: string
+): readonly [
+  q: string | null,
+  sp: string | null,
+  bp: string | null,
+  np: string | null,
+] {
+  const qPos = rawUrl.indexOf("?");
+  if (qPos === -1) {
+    return [null, null, null, null];
+  }
+  const hPos = rawUrl.indexOf("#", qPos + 1);
+  const end = hPos === -1 ? rawUrl.length : hPos;
+  let q: string | null = null;
+  let sp: string | null = null;
+  let bp: string | null = null;
+  let np: string | null = null;
+  let i = qPos + 1;
+
+  while (i < end) {
+    let amp = rawUrl.indexOf("&", i);
+    if (amp === -1 || amp > end) {
+      amp = end;
+    }
+    const eq = rawUrl.indexOf("=", i);
+    const keyEnd = eq === -1 || eq > amp ? amp : eq;
+    const keyLength = keyEnd - i;
+    let slot = -1;
+    if (keyLength === 1 && rawUrl.charCodeAt(i) === 113) {
+      slot = 0;
+    } else if (keyLength === 2 && rawUrl.charCodeAt(i + 1) === 112) {
+      const first = rawUrl.charCodeAt(i);
+      if (first === 115) {
+        slot = 1;
+      } else if (first === 98) {
+        slot = 2;
+      } else if (first === 110) {
+        slot = 3;
+      }
+    }
+
+    let current: string | null = null;
+    if (slot === 0) {
+      current = q;
+    } else if (slot === 1) {
+      current = sp;
+    } else if (slot === 2) {
+      current = bp;
+    } else if (slot === 3) {
+      current = np;
+    }
+    if (slot !== -1 && current === null) {
+      const value =
+        eq === -1 || eq > amp
+          ? ""
+          : decodeQueryComponent(rawUrl.substring(eq + 1, amp));
+      if (slot === 0) {
+        q = value;
+      } else if (slot === 1) {
+        sp = value;
+      } else if (slot === 2) {
+        bp = value;
+      } else {
+        np = value;
+      }
+    }
+    i = amp + 1;
+  }
+
+  return [q, sp, bp, np];
+}

--- a/src/shared/suggest-cookie.ts
+++ b/src/shared/suggest-cookie.ts
@@ -2,13 +2,22 @@ import {
   parseFrecencyCompact,
   serializeFrecencyCompact,
 } from "./frecency-serial";
+import {
+  DEFAULT_BANG_PREFIX,
+  DEFAULT_SNAP_PREFIX,
+  decodeTriggerPrefixes,
+  encodeTriggerPrefixes,
+  type TriggerPrefix,
+} from "./trigger-prefix";
 
 const SECTION_SEPARATOR = "|";
 const FREQUENCY_PREFIX = "f:";
 const CUSTOM_PREFIX = "c:";
 
 interface ParsedSuggestCookieCore {
+  bangPrefix: TriggerPrefix;
   provider: string;
+  snapPrefix: TriggerPrefix;
   trigger: string;
   customUrl: string | null;
 }
@@ -27,6 +36,11 @@ const DEFAULT_TRIGGER = "g";
 
 interface ParsedSuggestCookieWithValidation {
   settings: ParsedSuggestCookie;
+  hasInvalidContext: boolean;
+}
+
+export interface ParsedSuggestCookieContextWithValidation
+  extends ParsedSuggestCookieContext {
   hasInvalidContext: boolean;
 }
 
@@ -82,6 +96,75 @@ function parseCustom(
   }
 }
 
+function parseSuggestCookieContext(
+  raw: string,
+  firstPipe: number,
+  forCleanup: boolean,
+  target: ParsedSuggestCookieContext
+): boolean {
+  let hasInvalidContext = false;
+
+  if (firstPipe !== -1) {
+    let sectionStart = firstPipe + 1;
+
+    while (sectionStart <= raw.length) {
+      let sectionEnd = raw.indexOf(SECTION_SEPARATOR, sectionStart);
+      if (sectionEnd === -1) {
+        sectionEnd = raw.length;
+      }
+
+      if (sectionEnd > sectionStart) {
+        const section = raw.substring(sectionStart, sectionEnd);
+        if (section.startsWith(FREQUENCY_PREFIX)) {
+          const sectionVal = section.substring(2);
+          const result = parseFrecencyCompactSection(sectionVal, forCleanup);
+          target.frecent = result.value;
+          if (forCleanup && !result.valid) {
+            hasInvalidContext = true;
+            break;
+          }
+        } else if (section.startsWith(CUSTOM_PREFIX)) {
+          const result = parseCustom(section.substring(2), forCleanup);
+          target.custom = result.value;
+          if (forCleanup && !result.valid) {
+            hasInvalidContext = true;
+            break;
+          }
+        } else if (forCleanup) {
+          hasInvalidContext = true;
+          break;
+        }
+      }
+
+      if (sectionEnd === raw.length) {
+        break;
+      }
+
+      sectionStart = sectionEnd + 1;
+    }
+  }
+
+  return hasInvalidContext;
+}
+
+export function parseSuggestCookieContextValueWithValidation(
+  raw: string,
+  forCleanup: boolean
+): ParsedSuggestCookieContextWithValidation {
+  const context: ParsedSuggestCookieContextWithValidation = {
+    custom: [],
+    frecent: {},
+    hasInvalidContext: false,
+  };
+  context.hasInvalidContext = parseSuggestCookieContext(
+    raw,
+    raw.indexOf(SECTION_SEPARATOR),
+    forCleanup,
+    context
+  );
+  return context;
+}
+
 export function parseSuggestCookieValue(
   raw: string,
   includeBangContext: boolean
@@ -101,6 +184,7 @@ export function parseSuggestCookieValueWithValidation(
   let provider = "";
   let trigger = "";
   let customUrl = "";
+  let syntax = "";
 
   const comma1 = firstSection.indexOf(",");
   if (comma1 === -1) {
@@ -112,61 +196,41 @@ export function parseSuggestCookieValueWithValidation(
       trigger = firstSection.substring(comma1 + 1);
     } else {
       trigger = firstSection.substring(comma1 + 1, comma2);
-      customUrl = firstSection.substring(comma2 + 1);
-    }
-  }
-
-  let custom: string[] = [];
-  let frecent: Record<string, number> = {};
-  let hasInvalidContext = false;
-
-  if (includeBangContext && firstPipe !== -1) {
-    let sectionStart = firstPipe + 1;
-
-    while (sectionStart <= raw.length) {
-      let sectionEnd = raw.indexOf(SECTION_SEPARATOR, sectionStart);
-      if (sectionEnd === -1) {
-        sectionEnd = raw.length;
-      }
-
-      if (sectionEnd > sectionStart) {
-        const section = raw.substring(sectionStart, sectionEnd);
-        if (section.startsWith(FREQUENCY_PREFIX)) {
-          const sectionVal = section.substring(2);
-          const result = parseFrecencyCompactSection(sectionVal, forCleanup);
-          frecent = result.value;
-          if (forCleanup && !result.valid) {
-            hasInvalidContext = true;
-            break;
-          }
-        } else if (section.startsWith(CUSTOM_PREFIX)) {
-          const result = parseCustom(section.substring(2), forCleanup);
-          custom = result.value;
-          if (forCleanup && !result.valid) {
-            hasInvalidContext = true;
-            break;
-          }
-        } else if (forCleanup) {
-          hasInvalidContext = true;
-          break;
+      const customStart = comma2 + 1;
+      if (customStart < firstSection.length) {
+        const comma3 = firstSection.indexOf(",", customStart);
+        if (comma3 === -1) {
+          customUrl = firstSection.substring(customStart);
+        } else {
+          customUrl = firstSection.substring(customStart, comma3);
+          syntax = firstSection.substring(comma3 + 1);
         }
       }
-
-      if (sectionEnd === raw.length) {
-        break;
-      }
-
-      sectionStart = sectionEnd + 1;
     }
   }
 
+  const prefixes = syntax ? decodeTriggerPrefixes(syntax) : null;
+  const bangPrefix = prefixes?.[0] ?? DEFAULT_BANG_PREFIX;
+  const snapPrefix = prefixes?.[1] ?? DEFAULT_SNAP_PREFIX;
+
   const settings: ParsedSuggestCookie = {
+    bangPrefix,
     provider: provider || DEFAULT_PROVIDER,
+    snapPrefix,
     trigger: trigger || DEFAULT_TRIGGER,
     customUrl: customUrl ? safeDecodeURIComponent(customUrl) : null,
-    frecent,
-    custom,
+    frecent: {},
+    custom: [],
   };
+  let hasInvalidContext = false;
+  if (includeBangContext && firstPipe !== -1) {
+    hasInvalidContext = parseSuggestCookieContext(
+      raw,
+      firstPipe,
+      forCleanup,
+      settings
+    );
+  }
 
   return {
     settings,
@@ -179,9 +243,17 @@ export function encodeSuggestCookieValue(
   trigger: string,
   customUrl: string,
   custom: string[] = [],
-  frecent: Record<string, number> | null = null
+  frecent: Record<string, number> | null = null,
+  bangPrefix: TriggerPrefix = DEFAULT_BANG_PREFIX,
+  snapPrefix: TriggerPrefix = DEFAULT_SNAP_PREFIX
 ): string {
   let value = `${provider},${trigger},${encodeURIComponent(customUrl)}`;
+  if (
+    bangPrefix !== DEFAULT_BANG_PREFIX ||
+    snapPrefix !== DEFAULT_SNAP_PREFIX
+  ) {
+    value += `,${encodeTriggerPrefixes(bangPrefix, snapPrefix)}`;
+  }
 
   const compact = serializeFrecencyCompact(frecent);
   if (compact) {

--- a/src/shared/trigger-prefix.ts
+++ b/src/shared/trigger-prefix.ts
@@ -1,0 +1,42 @@
+export const TRIGGER_PREFIXES = ["!", "@", "$", ":", ";", "~"] as const;
+
+export type TriggerPrefix = (typeof TRIGGER_PREFIXES)[number];
+
+export const DEFAULT_BANG_PREFIX: TriggerPrefix = "!";
+export const DEFAULT_SNAP_PREFIX: TriggerPrefix = "@";
+
+export function isTriggerPrefix(value: unknown): value is TriggerPrefix {
+  return (
+    typeof value === "string" &&
+    (TRIGGER_PREFIXES as readonly string[]).includes(value)
+  );
+}
+
+export function resolveTriggerPrefixes(
+  bang: unknown,
+  snap: unknown
+): readonly [bang: TriggerPrefix, snap: TriggerPrefix] {
+  const bangPrefix = isTriggerPrefix(bang) ? bang : DEFAULT_BANG_PREFIX;
+  const snapPrefix = isTriggerPrefix(snap) ? snap : DEFAULT_SNAP_PREFIX;
+  return bangPrefix === snapPrefix
+    ? [DEFAULT_BANG_PREFIX, DEFAULT_SNAP_PREFIX]
+    : [bangPrefix, snapPrefix];
+}
+
+export function encodeTriggerPrefixes(
+  bang: TriggerPrefix,
+  snap: TriggerPrefix
+): string {
+  return `${TRIGGER_PREFIXES.indexOf(bang)}${TRIGGER_PREFIXES.indexOf(snap)}`;
+}
+
+export function decodeTriggerPrefixes(
+  value: string
+): readonly [bang: TriggerPrefix, snap: TriggerPrefix] | null {
+  if (value.length !== 2) {
+    return null;
+  }
+  const bang = TRIGGER_PREFIXES[value.charCodeAt(0) - 48];
+  const snap = TRIGGER_PREFIXES[value.charCodeAt(1) - 48];
+  return bang && snap && bang !== snap ? [bang, snap] : null;
+}

--- a/src/suggest-bang.ts
+++ b/src/suggest-bang.ts
@@ -387,10 +387,9 @@ export function bangSuggestions(
   partial: string,
   frecent: Record<string, number>,
   custom: string[],
-  isSnap?: boolean
+  triggerChar = "!"
 ): Response {
   const result = walkPrefix(partial);
-  const triggerChar = isSnap ? "@" : "!";
   let hasFrecent = false;
   for (const _ in frecent) {
     hasFrecent = true;

--- a/src/suggest.ts
+++ b/src/suggest.ts
@@ -1,13 +1,4 @@
-import {
-  CH_AT,
-  CH_CR,
-  CH_EXCL,
-  CH_FF,
-  CH_NL,
-  CH_SPACE,
-  CH_TAB,
-  CH_VTAB,
-} from "./shared/chars";
+import { CH_CR, CH_FF, CH_NL, CH_SPACE, CH_TAB, CH_VTAB } from "./shared/chars";
 import {
   JSON_HEADERS,
   SUGGEST_TRIGGER_PROVIDERS,
@@ -16,15 +7,24 @@ import {
 import { readQueryParam } from "./shared/raw-query";
 import {
   encodeSuggestCookieValue,
+  parseSuggestCookieContextValueWithValidation,
   parseSuggestCookieValue,
   parseSuggestCookieValueWithValidation,
 } from "./shared/suggest-cookie";
 import { resolveTemplateParts } from "./shared/template";
+import {
+  DEFAULT_BANG_PREFIX,
+  DEFAULT_SNAP_PREFIX,
+  isTriggerPrefix,
+  type TriggerPrefix,
+} from "./shared/trigger-prefix";
 import { bangSuggestions } from "./suggest-bang";
 
 export interface SuggestCoreSettings {
+  bangPrefix: TriggerPrefix;
   customUrl: string | null;
   provider: string;
+  snapPrefix: TriggerPrefix;
   trigger: string;
 }
 
@@ -41,6 +41,7 @@ export interface PartialBang {
   partial: string;
   prefix: string;
   isSnap?: boolean;
+  triggerPrefix: TriggerPrefix;
 }
 
 function isTrimWs(code: number): boolean {
@@ -97,7 +98,11 @@ function isSuggestionPayload(value: unknown): value is unknown[] {
   );
 }
 
-export function parsePartialBang(q: string): PartialBang | null {
+export function parsePartialBang(
+  q: string,
+  bangPrefix: TriggerPrefix = DEFAULT_BANG_PREFIX,
+  snapPrefix: TriggerPrefix = DEFAULT_SNAP_PREFIX
+): PartialBang | null {
   let start = 0;
   let end = q.length;
 
@@ -112,8 +117,10 @@ export function parsePartialBang(q: string): PartialBang | null {
   }
 
   const c0 = q.charCodeAt(start);
+  const bangCode = bangPrefix.charCodeAt(0);
+  const snapCode = snapPrefix.charCodeAt(0);
 
-  if (c0 === CH_EXCL || c0 === CH_AT) {
+  if (c0 === bangCode || c0 === snapCode) {
     for (let i = start + 1; i < end; i++) {
       if (q.charCodeAt(i) === CH_SPACE) {
         return null;
@@ -122,14 +129,15 @@ export function parsePartialBang(q: string): PartialBang | null {
     return {
       prefix: "",
       partial: q.substring(start + 1, end).toLowerCase(),
-      isSnap: c0 === CH_AT || undefined,
+      isSnap: c0 === snapCode || undefined,
+      triggerPrefix: c0 === snapCode ? snapPrefix : bangPrefix,
     };
   }
 
   for (let i = end - 2; i >= start; i--) {
     const ci = q.charCodeAt(i);
     const ci1 = q.charCodeAt(i + 1);
-    if (ci !== CH_SPACE || (ci1 !== CH_EXCL && ci1 !== CH_AT)) {
+    if (ci !== CH_SPACE || (ci1 !== bangCode && ci1 !== snapCode)) {
       continue;
     }
     const triggerStart = i + 2;
@@ -141,7 +149,8 @@ export function parsePartialBang(q: string): PartialBang | null {
     return {
       prefix: q.substring(start, i + 1),
       partial: q.substring(triggerStart, end).toLowerCase(),
-      isSnap: ci1 === CH_AT || undefined,
+      isSnap: ci1 === snapCode || undefined,
+      triggerPrefix: ci1 === snapCode ? snapPrefix : bangPrefix,
     };
   }
 
@@ -201,7 +210,9 @@ function parseCookieInternalWithRewrite(
     settings.trigger,
     settings.customUrl || "",
     [],
-    {}
+    {},
+    settings.bangPrefix,
+    settings.snapPrefix
   );
 
   return {
@@ -215,11 +226,50 @@ export interface SuggestSettingsWithCleanup {
   rewrittenSuggestCookie: string | null;
 }
 
+export function parseBangSettingsFromRequestWithCleanup(
+  request: Request,
+  settings: SuggestSettings
+): SuggestSettingsWithCleanup {
+  const suggestRaw = readCookieValue(
+    request.headers.get("Cookie") || "",
+    "suggest"
+  );
+  if (suggestRaw === null) {
+    return { settings, rewrittenSuggestCookie: null };
+  }
+
+  const { custom, frecent, hasInvalidContext } =
+    parseSuggestCookieContextValueWithValidation(suggestRaw, true);
+  settings.custom = custom;
+  settings.frecent = frecent;
+  if (!hasInvalidContext) {
+    return { settings, rewrittenSuggestCookie: null };
+  }
+
+  const cookieSettings = parseSuggestCookieValue(suggestRaw, false);
+  settings.custom = [];
+  settings.frecent = {};
+  return {
+    settings,
+    rewrittenSuggestCookie: encodeSuggestCookieValue(
+      cookieSettings.provider,
+      cookieSettings.trigger,
+      cookieSettings.customUrl || "",
+      [],
+      {},
+      cookieSettings.bangPrefix,
+      cookieSettings.snapPrefix
+    ),
+  };
+}
+
 export function parseSettingsFromRawUrlWithCleanup(
   rawUrl: string,
   request: Request,
   spOverride?: string | null,
-  includeBangContext = true
+  includeBangContext = true,
+  bangPrefixOverride?: string | null,
+  snapPrefixOverride?: string | null
 ): SuggestSettingsWithCleanup {
   const { settings, rewrittenSuggestCookie } = parseCookieInternalWithRewrite(
     request.headers.get("Cookie") || "",
@@ -227,10 +277,17 @@ export function parseSettingsFromRawUrlWithCleanup(
     true
   );
 
-  const sp = spOverride ?? readQueryParam(rawUrl, "sp");
+  const sp =
+    spOverride === undefined ? readQueryParam(rawUrl, "sp") : spOverride;
   if (sp) {
     settings.provider = sp;
   }
+  applyTriggerPrefixOverrides(
+    rawUrl,
+    settings,
+    bangPrefixOverride,
+    snapPrefixOverride
+  );
 
   return {
     settings,
@@ -242,7 +299,9 @@ export function parseSettingsFromRawUrl(
   rawUrl: string,
   request: Request,
   spOverride?: string | null,
-  includeBangContext = true
+  includeBangContext = true,
+  bangPrefixOverride?: string | null,
+  snapPrefixOverride?: string | null
 ): SuggestSettings {
   const settings = parseCookieInternalWithRewrite(
     request.headers.get("Cookie") || "",
@@ -250,10 +309,17 @@ export function parseSettingsFromRawUrl(
     false
   ).settings;
 
-  const sp = spOverride ?? readQueryParam(rawUrl, "sp");
+  const sp =
+    spOverride === undefined ? readQueryParam(rawUrl, "sp") : spOverride;
   if (sp) {
     settings.provider = sp;
   }
+  applyTriggerPrefixOverrides(
+    rawUrl,
+    settings,
+    bangPrefixOverride,
+    snapPrefixOverride
+  );
 
   return settings;
 }
@@ -264,12 +330,45 @@ export function parseSettings(url: URL, request: Request): SuggestSettings {
 
 function defaultSettings(): SuggestSettings {
   return {
+    bangPrefix: DEFAULT_BANG_PREFIX,
     provider: "default",
+    snapPrefix: DEFAULT_SNAP_PREFIX,
     trigger: "g",
     customUrl: null,
     frecent: {},
     custom: [],
   };
+}
+
+function applyTriggerPrefixOverrides(
+  rawUrl: string,
+  settings: SuggestSettings,
+  bangPrefixOverride?: string | null,
+  snapPrefixOverride?: string | null
+): void {
+  if (
+    bangPrefixOverride === undefined &&
+    snapPrefixOverride === undefined &&
+    !(rawUrl.includes("bp=") || rawUrl.includes("np="))
+  ) {
+    return;
+  }
+  const bangPrefix =
+    bangPrefixOverride === undefined
+      ? readQueryParam(rawUrl, "bp")
+      : bangPrefixOverride;
+  const snapPrefix =
+    snapPrefixOverride === undefined
+      ? readQueryParam(rawUrl, "np")
+      : snapPrefixOverride;
+  if (
+    isTriggerPrefix(bangPrefix) &&
+    isTriggerPrefix(snapPrefix) &&
+    bangPrefix !== snapPrefix
+  ) {
+    settings.bangPrefix = bangPrefix;
+    settings.snapPrefix = snapPrefix;
+  }
 }
 
 function readCookieValue(header: string, name: string): string | null {
@@ -298,7 +397,10 @@ export async function suggest(
   bangOverride?: PartialBang | null,
   allowUnsafeCustomUrls = false
 ): Promise<Response> {
-  const bang = bangOverride ?? parsePartialBang(query);
+  const bang =
+    bangOverride === undefined
+      ? parsePartialBang(query, settings.bangPrefix, settings.snapPrefix)
+      : bangOverride;
   if (bang) {
     return bangSuggestions(
       query,
@@ -306,7 +408,7 @@ export async function suggest(
       bang.partial,
       settings.frecent,
       settings.custom,
-      bang.isSnap
+      bang.triggerPrefix
     );
   }
 

--- a/src/sw/idb.ts
+++ b/src/sw/idb.ts
@@ -18,13 +18,19 @@ import {
 import { hashFNV1a } from "../shared/hash";
 import { idbWrap, openDB, resetDB } from "../shared/idb";
 import { compileSnapTarget, type SnapTargetParts } from "../shared/snap-target";
+import { resolveTriggerPrefixes } from "../shared/trigger-prefix";
 import { lookupBang } from "./bang-data";
 import {
   buildTopFrecency,
   type TopFrecencyEntry,
   updateTopFrecencyOnIncrement,
 } from "./frecency";
-import type { CustomUrlParts, RedirectSettings, UrlParts } from "./redirect";
+import {
+  type CustomUrlParts,
+  compileTriggerSyntax,
+  type RedirectSettings,
+  type UrlParts,
+} from "./redirect";
 
 function splitUrl(url: string): UrlParts {
   const idx = url.indexOf("{}");
@@ -105,6 +111,10 @@ export function readRedirectSettings(): Promise<RedirectSettings> {
         }
         const defaultUrl = defaultEntry || splitUrl(DEFAULT_URL);
         const effectiveDefaultBang = defaultEntry ? defaultBang : "g";
+        const [bangPrefix, snapPrefix] = resolveTriggerPrefixes(
+          settingsMap["bang-prefix"],
+          settingsMap["snap-prefix"]
+        );
 
         const luckyProvider = settingsMap["lucky-provider"] ?? "default";
         let luckyUrl: UrlParts | null;
@@ -134,7 +144,13 @@ export function readRedirectSettings(): Promise<RedirectSettings> {
             break;
         }
 
-        cachedRedirect = { defaultUrl, custom, luckyUrl };
+        const syntax = compileTriggerSyntax(bangPrefix, snapPrefix);
+        cachedRedirect = {
+          defaultUrl,
+          custom,
+          luckyUrl,
+          ...(syntax ? { syntax } : {}),
+        };
       } catch {
         cachedRedirect = {
           defaultUrl: splitUrl(DEFAULT_URL),

--- a/src/sw/redirect.ts
+++ b/src/sw/redirect.ts
@@ -10,18 +10,19 @@ import {
 } from "../shared/capture-template";
 import {
   CH_0,
-  CH_1,
   CH_2,
-  CH_4,
-  CH_AT,
   CH_BSLASH,
-  CH_EXCL,
   CH_F,
   CH_f,
   CH_PERCENT,
   CH_PLUS,
 } from "../shared/chars";
 import type { SnapTargetParts } from "../shared/snap-target";
+import {
+  DEFAULT_BANG_PREFIX,
+  DEFAULT_SNAP_PREFIX,
+  type TriggerPrefix,
+} from "../shared/trigger-prefix";
 import { lookupBang } from "./bang-data";
 
 // NOTE: pos + char-width packed into one int to skip tuple alloc:
@@ -35,54 +36,85 @@ type CaptureUrlPartsWithSnap = readonly [...CaptureUrlParts, SnapTargetParts];
 type SimpleEntry = UrlParts | UrlPartsWithSnap;
 type CaptureEntry = CaptureUrlParts | CaptureUrlPartsWithSnap;
 export type CustomUrlParts = SimpleEntry | CaptureEntry;
+export type TriggerSyntax = readonly [bangMarker: number, snapMarker: number];
 
 export interface RedirectSettings {
   custom: Record<string, CustomUrlParts>;
   defaultUrl: UrlParts;
   luckyUrl: UrlParts | null;
+  syntax?: TriggerSyntax;
 }
 
-function isEncodedExclAt(s: string, i: number): boolean {
+function hexCode(nibble: number): number {
+  return nibble < 10 ? 48 + nibble : 87 + nibble;
+}
+
+function compileMarker(code: number): number {
+  return code | (hexCode(code >> 4) << 8) | (hexCode(code & 0xf) << 16);
+}
+
+const DEFAULT_BANG_MARKER = compileMarker(33);
+const DEFAULT_SNAP_MARKER = compileMarker(64);
+
+export function compileTriggerSyntax(
+  bangPrefix: TriggerPrefix,
+  snapPrefix: TriggerPrefix
+): TriggerSyntax | undefined {
+  if (
+    bangPrefix === DEFAULT_BANG_PREFIX &&
+    snapPrefix === DEFAULT_SNAP_PREFIX
+  ) {
+    return undefined;
+  }
+  return [
+    compileMarker(bangPrefix.charCodeAt(0)),
+    compileMarker(snapPrefix.charCodeAt(0)),
+  ];
+}
+
+function isEncodedMarkerAt(s: string, i: number, marker: number): boolean {
   return (
     s.charCodeAt(i) === CH_PERCENT &&
-    s.charCodeAt(i + 1) === CH_2 &&
-    s.charCodeAt(i + 2) === CH_1
+    (s.charCodeAt(i + 1) | ((s.charCodeAt(i + 2) | 32) << 8)) === marker >> 8
   );
 }
 
-function isEncodedAtAt(s: string, i: number): boolean {
-  return (
-    s.charCodeAt(i) === CH_PERCENT &&
-    s.charCodeAt(i + 1) === CH_4 &&
-    s.charCodeAt(i + 2) === CH_0
-  );
-}
+let _sawSnap = false;
 
-let _sawAt = false;
-
-function findExcl(s: string, start: number, end: number): number {
-  let sawAt = false;
+function findBangMarker(
+  s: string,
+  start: number,
+  end: number,
+  bangMarker: number,
+  snapMarker: number
+): number {
+  const bangCode = bangMarker & 0xff;
+  const snapCode = snapMarker & 0xff;
+  const bangEncoded = bangMarker >> 8;
+  const snapEncoded = snapMarker >> 8;
+  let sawSnap = false;
   for (let i = start; i < end; i++) {
     const c = s.charCodeAt(i);
-    if (c === CH_EXCL) {
-      _sawAt = sawAt;
+    if (c === bangCode) {
+      _sawSnap = sawSnap;
       return (i << 2) | 1;
     }
-    if (c === CH_AT) {
-      sawAt = true;
+    if (c === snapCode) {
+      sawSnap = true;
     } else if (c === CH_PERCENT && i + 2 < end) {
       const c1 = s.charCodeAt(i + 1);
-      const c2 = s.charCodeAt(i + 2);
-      if (c1 === CH_2 && c2 === CH_1) {
-        _sawAt = sawAt;
+      const c2 = s.charCodeAt(i + 2) | 32;
+      const encoded = c1 | (c2 << 8);
+      if (encoded === bangEncoded) {
+        _sawSnap = sawSnap;
         return (i << 2) | 3;
       }
-      if (c1 === CH_4 && c2 === CH_0) {
-        sawAt = true;
+      if (encoded === snapEncoded) {
+        sawSnap = true;
       }
     }
   }
-  _sawAt = sawAt;
+  _sawSnap = sawSnap;
   return -1;
 }
 
@@ -103,25 +135,32 @@ function findSpace(s: string, from: number, end: number): number {
   return -1;
 }
 
-function findLastSpaceExcl(s: string, start: number, end: number): number {
+function findLastSpaceMarker(
+  s: string,
+  start: number,
+  end: number,
+  marker: number
+): number {
+  const markerCode = marker & 0xff;
+  const markerEncoded = marker >> 8;
   for (let i = end - 1; i >= start; i--) {
     const c = s.charCodeAt(i);
-    let exclWidth = 0;
-    if (c === CH_EXCL) {
-      exclWidth = 1;
+    let markerWidth = 0;
+    if (c === markerCode) {
+      markerWidth = 1;
     } else if (
       c === CH_PERCENT &&
       i + 2 < end &&
-      s.charCodeAt(i + 1) === CH_2 &&
-      s.charCodeAt(i + 2) === CH_1
+      (s.charCodeAt(i + 1) | ((s.charCodeAt(i + 2) | 32) << 8)) ===
+        markerEncoded
     ) {
-      exclWidth = 3;
+      markerWidth = 3;
     }
-    if (!exclWidth) {
+    if (!markerWidth) {
       continue;
     }
     if (i >= start + 1 && s.charCodeAt(i - 1) === CH_PLUS) {
-      return ((i - 1) << 4) | (1 << 2) | exclWidth;
+      return ((i - 1) << 4) | (1 << 2) | markerWidth;
     }
     if (
       i >= start + 3 &&
@@ -129,39 +168,7 @@ function findLastSpaceExcl(s: string, start: number, end: number): number {
       s.charCodeAt(i - 2) === CH_2 &&
       s.charCodeAt(i - 1) === CH_0
     ) {
-      return ((i - 3) << 4) | (3 << 2) | exclWidth;
-    }
-  }
-  return -1;
-}
-
-function findLastSpaceAt(s: string, start: number, end: number): number {
-  for (let i = end - 1; i >= start; i--) {
-    const c = s.charCodeAt(i);
-    let atWidth = 0;
-    if (c === CH_AT) {
-      atWidth = 1;
-    } else if (
-      c === CH_PERCENT &&
-      i + 2 < end &&
-      s.charCodeAt(i + 1) === CH_4 &&
-      s.charCodeAt(i + 2) === CH_0
-    ) {
-      atWidth = 3;
-    }
-    if (!atWidth) {
-      continue;
-    }
-    if (i >= start + 1 && s.charCodeAt(i - 1) === CH_PLUS) {
-      return ((i - 1) << 4) | (1 << 2) | atWidth;
-    }
-    if (
-      i >= start + 3 &&
-      s.charCodeAt(i - 3) === CH_PERCENT &&
-      s.charCodeAt(i - 2) === CH_2 &&
-      s.charCodeAt(i - 1) === CH_0
-    ) {
-      return ((i - 3) << 4) | (3 << 2) | atWidth;
+      return ((i - 3) << 4) | (3 << 2) | markerWidth;
     }
   }
   return -1;
@@ -615,9 +622,11 @@ function findTrailingBareBang(
   s: string,
   start: number,
   end: number,
-  lastChar: number
+  lastChar: number,
+  bangMarker: number
 ): number {
-  if (lastChar === CH_EXCL) {
+  const bangCode = bangMarker & 0xff;
+  if (lastChar === bangCode) {
     // "query+!"
     if (s.charCodeAt(end - 2) === CH_PLUS) {
       return end - 2;
@@ -633,7 +642,7 @@ function findTrailingBareBang(
     }
   }
   // "query+%21" / "query%20%21"
-  if (end - start >= 3 && isEncodedExclAt(s, end - 3)) {
+  if (end - start >= 3 && isEncodedMarkerAt(s, end - 3, bangMarker)) {
     const beforeExcl = end - 3;
     if (s.charCodeAt(beforeExcl - 1) === CH_PLUS) {
       return beforeExcl - 1;
@@ -672,10 +681,63 @@ function extractTrigger(s: string, from: number, to: number): string {
   return from === 0 && to === s.length ? s : s.substring(from, to);
 }
 
+function resolvePrefixSnap(
+  rawQuery: string,
+  start: number,
+  end: number,
+  afterAt: number,
+  defaultUrl: UrlParts,
+  custom: Record<string, CustomUrlParts>
+): [string, string | null] {
+  if (afterAt >= end) {
+    return ["/", null];
+  }
+
+  const cAfterAt = rawQuery.charCodeAt(afterAt);
+  let atSpaceWidth = 0;
+  if (cAfterAt === CH_PLUS) {
+    atSpaceWidth = 1;
+  } else if (
+    cAfterAt === CH_PERCENT &&
+    rawQuery.charCodeAt(afterAt + 1) === CH_2 &&
+    rawQuery.charCodeAt(afterAt + 2) === CH_0
+  ) {
+    atSpaceWidth = 3;
+  }
+  if (atSpaceWidth) {
+    return [buildUrl(defaultUrl, rawQuery, start, end), null];
+  }
+
+  const spPacked = findSpace(rawQuery, afterAt, end);
+  const sp = spPacked === -1 ? -1 : spPacked >> 2;
+  const spLen = spPacked === -1 ? 0 : spPacked & 0b11;
+  const triggerEnd = sp === -1 ? end : sp;
+  const trigger = extractTrigger(rawQuery, afterAt, triggerEnd);
+
+  if (sp === -1 || sp + spLen >= end) {
+    const origin = resolveSnapOrigin(trigger, custom, _lastHash);
+    if (!origin) {
+      return [buildUrl(defaultUrl, rawQuery, start, end), null];
+    }
+    return [origin, trigger];
+  }
+
+  const siteFilter = resolveSnapSiteFilter(trigger, custom, _lastHash);
+  if (!siteFilter) {
+    return [buildUrl(defaultUrl, rawQuery, start, end), null];
+  }
+  return [
+    buildSnapUrl(defaultUrl, siteFilter, rawQuery, sp + spLen, end),
+    trigger,
+  ];
+}
+
 function resolveRaw(
   rawQuery: string,
-  { defaultUrl, custom, luckyUrl }: RedirectSettings
+  settings: RedirectSettings
 ): [string, string | null] {
+  const { defaultUrl, custom, luckyUrl } = settings;
+  const syntax = settings.syntax;
   const len = rawQuery.length;
 
   let start = 0;
@@ -729,23 +791,29 @@ function resolveRaw(
     ];
   }
 
+  const bangMarker = syntax ? syntax[0] : DEFAULT_BANG_MARKER;
+  const snapMarker = syntax ? syntax[1] : DEFAULT_SNAP_MARKER;
+  const bangCode = bangMarker & 0xff;
+  const snapCode = snapMarker & 0xff;
+
   let exclStart = -1;
   let exclWidth = 0;
-  if (c0 === CH_EXCL) {
-    exclStart = start;
-    exclWidth = 1;
-  } else if (end - start >= 3 && isEncodedExclAt(rawQuery, start)) {
-    exclStart = start;
-    exclWidth = 3;
-  }
-
   let atStart = -1;
   let atWidth = 0;
-  if (exclStart === -1) {
-    if (c0 === CH_AT) {
-      atStart = start;
-      atWidth = 1;
-    } else if (end - start >= 3 && isEncodedAtAt(rawQuery, start)) {
+  if (c0 === bangCode) {
+    exclStart = start;
+    exclWidth = 1;
+  } else if (c0 === snapCode) {
+    atStart = start;
+    atWidth = 1;
+  } else if (end - start >= 3 && c0 === CH_PERCENT) {
+    const encoded =
+      rawQuery.charCodeAt(start + 1) |
+      ((rawQuery.charCodeAt(start + 2) | 32) << 8);
+    if (encoded === bangMarker >> 8) {
+      exclStart = start;
+      exclWidth = 3;
+    } else if (encoded === snapMarker >> 8) {
       atStart = start;
       atWidth = 3;
     }
@@ -812,53 +880,25 @@ function resolveRaw(
 
   // "@trigger+query" or "@trigger" — prefix snap
   if (atStart !== -1) {
-    const afterAt = atStart + atWidth;
-    if (afterAt >= end) {
-      return ["/", null];
-    }
-
-    const cAfterAt = rawQuery.charCodeAt(afterAt);
-    let atSpaceWidth = 0;
-    if (cAfterAt === CH_PLUS) {
-      atSpaceWidth = 1;
-    } else if (
-      cAfterAt === CH_PERCENT &&
-      rawQuery.charCodeAt(afterAt + 1) === CH_2 &&
-      rawQuery.charCodeAt(afterAt + 2) === CH_0
-    ) {
-      atSpaceWidth = 3;
-    }
-    if (atSpaceWidth) {
-      return [buildUrl(defaultUrl, rawQuery, start, end), null];
-    }
-
-    const spPacked = findSpace(rawQuery, afterAt, end);
-    const sp = spPacked === -1 ? -1 : spPacked >> 2;
-    const spLen = spPacked === -1 ? 0 : spPacked & 0b11;
-    const triggerEnd = sp === -1 ? end : sp;
-    const trigger = extractTrigger(rawQuery, afterAt, triggerEnd);
-
-    if (sp === -1 || sp + spLen >= end) {
-      const origin = resolveSnapOrigin(trigger, custom, _lastHash);
-      if (!origin) {
-        return [buildUrl(defaultUrl, rawQuery, start, end), null];
-      }
-      return [origin, trigger];
-    }
-
-    const siteFilter = resolveSnapSiteFilter(trigger, custom, _lastHash);
-    if (!siteFilter) {
-      return [buildUrl(defaultUrl, rawQuery, start, end), null];
-    }
-    return [
-      buildSnapUrl(defaultUrl, siteFilter, rawQuery, sp + spLen, end),
-      trigger,
-    ];
+    return resolvePrefixSnap(
+      rawQuery,
+      start,
+      end,
+      atStart + atWidth,
+      defaultUrl,
+      custom
+    );
   }
 
   // "query+!" / "query%20!" / "query+%21" / "query%20%21" — trailing bare bang lucky
   const lastChar = rawQuery.charCodeAt(end - 1);
-  const trailingTermEnd = findTrailingBareBang(rawQuery, start, end, lastChar);
+  const trailingTermEnd = findTrailingBareBang(
+    rawQuery,
+    start,
+    end,
+    lastChar,
+    bangMarker
+  );
   if (trailingTermEnd !== -1) {
     if (trailingTermEnd <= start) {
       return ["/", null];
@@ -869,10 +909,16 @@ function resolveRaw(
     ];
   }
 
-  const exclPacked = findExcl(rawQuery, start, end);
+  const exclPacked = findBangMarker(
+    rawQuery,
+    start,
+    end,
+    bangMarker,
+    snapMarker
+  );
   if (exclPacked === -1) {
-    if (_sawAt) {
-      const snapPacked = findLastSpaceAt(rawQuery, start, end);
+    if (_sawSnap) {
+      const snapPacked = findLastSpaceMarker(rawQuery, start, end, snapMarker);
       if (snapPacked !== -1) {
         const spaceBeforeAtPos = snapPacked >> 4;
         const spaceBeforeAtWidth = (snapPacked >> 2) & 0b11;
@@ -957,7 +1003,7 @@ function resolveRaw(
   }
 
   // "cats+!g"
-  const suffixPacked = findLastSpaceExcl(rawQuery, start, end);
+  const suffixPacked = findLastSpaceMarker(rawQuery, start, end, bangMarker);
   if (suffixPacked !== -1) {
     const spaceBeforeBangPos = suffixPacked >> 4;
     const spaceBeforeBangWidth = (suffixPacked >> 2) & 0b11;
@@ -985,10 +1031,10 @@ function resolveRaw(
 
   // "cats+g!"
   if (
-    lastChar === CH_EXCL ||
-    (end >= 3 && isEncodedExclAt(rawQuery, end - exclCharWidth))
+    lastChar === bangCode ||
+    (end >= 3 && isEncodedMarkerAt(rawQuery, end - exclCharWidth, bangMarker))
   ) {
-    const bangExclEnd = lastChar === CH_EXCL ? end - 1 : end - 3;
+    const bangExclEnd = lastChar === bangCode ? end - 1 : end - 3;
     const lastSpPacked = findLastSpace(rawQuery, start, bangExclEnd - 1);
     if (lastSpPacked !== -1) {
       const lastSpPos = lastSpPacked >> 2;

--- a/src/sw/sw.ts
+++ b/src/sw/sw.ts
@@ -174,7 +174,9 @@ function queueBangSideEffects(e: FetchEvent, trigger: string): void {
               parsed.trigger,
               parsed.customUrl || "",
               parsed.custom,
-              frecency
+              frecency,
+              parsed.bangPrefix,
+              parsed.snapPrefix
             ),
             path: "/",
             expires: Date.now() + COOKIE_MAX_AGE_S * 1000,

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -1,3 +1,4 @@
+import { resolveTriggerPrefixes } from "../shared/trigger-prefix";
 import { setSuggestCookie } from "./cookie";
 import { DB, readCustomBangs } from "./db";
 import { $ } from "./dom";
@@ -14,15 +15,27 @@ const db = new DB();
 
 async function syncSuggestCookie() {
   const [settings, custom] = await Promise.all([
-    db.getMultipleSettings(["suggest-provider", "default-bang", "suggest-url"]),
+    db.getMultipleSettings([
+      "suggest-provider",
+      "default-bang",
+      "suggest-url",
+      "bang-prefix",
+      "snap-prefix",
+    ]),
     readCustomBangs(db),
   ]);
 
+  const [bangPrefix, snapPrefix] = resolveTriggerPrefixes(
+    settings[3],
+    settings[4]
+  );
   setSuggestCookie(
     resolveSuggestProvider(settings[0], __ALLOW_UNSAFE_CUSTOM_SUGGEST_URLS__),
     settings[1] || "g",
     settings[2] || "",
-    custom
+    custom,
+    bangPrefix,
+    snapPrefix
   );
 }
 
@@ -31,7 +44,7 @@ function init() {
   syncSuggestCookie();
 
   initLiquidMetal($<HTMLCanvasElement>("#metal-canvas"), "flashbang");
-  const refreshHomeCatalog = initHome(db);
+  const home = initHome(db);
 
   const { openDialog } = setupDialog({
     closeButton: $("#modal-close"),
@@ -40,7 +53,9 @@ function init() {
       void initSettings(
         db,
         __ALLOW_UNSAFE_CUSTOM_SUGGEST_URLS__,
-        refreshHomeCatalog
+        home.refreshCatalog,
+        home.setPrefixes,
+        home.setFirefoxSuggestProvider
       ),
     openButton: $("#gear-btn"),
   });

--- a/src/ui/cookie.ts
+++ b/src/ui/cookie.ts
@@ -1,12 +1,27 @@
 import { COOKIE_MAX_AGE_S } from "../shared/constants";
 import { encodeSuggestCookieValue } from "../shared/suggest-cookie";
+import {
+  DEFAULT_BANG_PREFIX,
+  DEFAULT_SNAP_PREFIX,
+  type TriggerPrefix,
+} from "../shared/trigger-prefix";
 
 export function setSuggestCookie(
   provider: string,
   trigger: string,
   customUrl: string,
-  custom?: string[]
+  custom?: string[],
+  bangPrefix: TriggerPrefix = DEFAULT_BANG_PREFIX,
+  snapPrefix: TriggerPrefix = DEFAULT_SNAP_PREFIX
 ) {
-  const value = encodeSuggestCookieValue(provider, trigger, customUrl, custom);
+  const value = encodeSuggestCookieValue(
+    provider,
+    trigger,
+    customUrl,
+    custom,
+    null,
+    bangPrefix,
+    snapPrefix
+  );
   document.cookie = `suggest=${value};path=/;max-age=${COOKIE_MAX_AGE_S};SameSite=Lax;Secure`;
 }

--- a/src/ui/db.ts
+++ b/src/ui/db.ts
@@ -8,8 +8,13 @@ import { LUCKY_URLS, SUGGEST_URLS } from "../shared/constants";
 import { validateCustomTrigger } from "../shared/custom-trigger";
 import { idbWrap, openDB } from "../shared/idb";
 import { validateSnapTarget } from "../shared/snap-target";
+import {
+  DEFAULT_BANG_PREFIX,
+  DEFAULT_SNAP_PREFIX,
+  isTriggerPrefix,
+} from "../shared/trigger-prefix";
 
-export const SETTINGS_SCHEMA_VERSION = 1;
+export const SETTINGS_SCHEMA_VERSION = 2;
 
 const VALID_SETTING_KEYS = new Map([
   ["defaultBang", "default-bang"],
@@ -17,6 +22,8 @@ const VALID_SETTING_KEYS = new Map([
   ["suggestUrl", "suggest-url"],
   ["luckyProvider", "lucky-provider"],
   ["luckyUrl", "lucky-url"],
+  ["bangPrefix", "bang-prefix"],
+  ["snapPrefix", "snap-prefix"],
 ]);
 const CONFIGURABLE_SETTING_KEYS = [...VALID_SETTING_KEYS.values()];
 
@@ -82,7 +89,11 @@ function prepareImport(data: unknown): PreparedImport {
   }
 
   const versioned = Object.hasOwn(data, "schemaVersion");
-  if (versioned && data.schemaVersion !== SETTINGS_SCHEMA_VERSION) {
+  if (
+    versioned &&
+    data.schemaVersion !== 1 &&
+    data.schemaVersion !== SETTINGS_SCHEMA_VERSION
+  ) {
     throw new Error("Unsupported settings schema version");
   }
   const hasSettings = Object.hasOwn(data, "settings");
@@ -100,6 +111,8 @@ function prepareImport(data: unknown): PreparedImport {
   let suggestUrl: string | null = null;
   let luckyProvider: string | null = null;
   let luckyUrl: string | null = null;
+  let bangPrefix = DEFAULT_BANG_PREFIX;
+  let snapPrefix = DEFAULT_SNAP_PREFIX;
   if (hasSettings) {
     if (!isRecord(data.settings)) {
       throw new Error("Invalid settings data");
@@ -149,6 +162,16 @@ function prepareImport(data: unknown): PreparedImport {
         if (error) {
           throw new Error(`Invalid lucky URL template: ${error}`);
         }
+      } else if (exportKey === "bangPrefix") {
+        if (!isTriggerPrefix(value)) {
+          throw new Error("Invalid bang prefix");
+        }
+        bangPrefix = value;
+      } else if (exportKey === "snapPrefix") {
+        if (!isTriggerPrefix(value)) {
+          throw new Error("Invalid snap prefix");
+        }
+        snapPrefix = value;
       }
       if (value) {
         settings.push({ key: idbKey, value });
@@ -160,6 +183,9 @@ function prepareImport(data: unknown): PreparedImport {
   }
   if (luckyProvider === "custom" && !luckyUrl) {
     throw new Error("Custom lucky provider requires a URL template");
+  }
+  if (bangPrefix === snapPrefix) {
+    throw new Error("Bang and snap prefixes must be different");
   }
 
   const customBangs: CustomBangRecord[] = [];
@@ -329,6 +355,8 @@ export class DB {
       suggestUrl,
       luckyProvider,
       luckyUrl,
+      bangPrefix,
+      snapPrefix,
       customBangs,
     ] = await Promise.all([
       idbWrap<{ key: string; value: string } | undefined>(
@@ -346,6 +374,12 @@ export class DB {
       idbWrap<{ key: string; value: string } | undefined>(
         settingsStore.get("lucky-url")
       ),
+      idbWrap<{ key: string; value: string } | undefined>(
+        settingsStore.get("bang-prefix")
+      ),
+      idbWrap<{ key: string; value: string } | undefined>(
+        settingsStore.get("snap-prefix")
+      ),
       idbWrap<CustomBangRecord[]>(tx.objectStore("custom-bangs").getAll()),
     ]);
     const result = {
@@ -356,6 +390,8 @@ export class DB {
         suggestUrl: suggestUrl?.value ?? null,
         luckyProvider: luckyProvider?.value ?? null,
         luckyUrl: luckyUrl?.value ?? null,
+        bangPrefix: bangPrefix?.value ?? null,
+        snapPrefix: snapPrefix?.value ?? null,
       },
       customBangs,
       exported: new Date().toISOString(),

--- a/src/ui/firefox-suggest.ts
+++ b/src/ui/firefox-suggest.ts
@@ -1,0 +1,27 @@
+import {
+  DEFAULT_BANG_PREFIX,
+  DEFAULT_SNAP_PREFIX,
+  type TriggerPrefix,
+} from "../shared/trigger-prefix";
+
+export interface FirefoxSuggestionConfig {
+  bangPrefix: TriggerPrefix;
+  provider: string;
+  snapPrefix: TriggerPrefix;
+}
+
+export function isFirefoxUserAgent(userAgent: string): boolean {
+  const value = userAgent.toLowerCase();
+  return value.includes("firefox") || value.includes("fxios");
+}
+
+export function firefoxSuggestionUrl(
+  origin: string,
+  { bangPrefix, provider, snapPrefix }: FirefoxSuggestionConfig
+): string {
+  const syntax =
+    bangPrefix === DEFAULT_BANG_PREFIX && snapPrefix === DEFAULT_SNAP_PREFIX
+      ? ""
+      : `&bp=${encodeURIComponent(bangPrefix)}&np=${encodeURIComponent(snapPrefix)}`;
+  return `${origin}/suggest?q=%s&sp=${provider}${syntax}`;
+}

--- a/src/ui/home/address-bar-setup.ts
+++ b/src/ui/home/address-bar-setup.ts
@@ -1,5 +1,10 @@
 import { copyText } from "../clipboard";
 import { $, el } from "../dom";
+import {
+  type FirefoxSuggestionConfig,
+  firefoxSuggestionUrl,
+  isFirefoxUserAgent,
+} from "../firefox-suggest";
 import { setupDialog } from "../modal";
 
 type AddressBarBrowser = "brave" | "chrome" | "edge" | "firefox" | "safari";
@@ -104,7 +109,7 @@ export function detectAddressBarBrowser(
   isBrave = false
 ): AddressBarBrowser {
   const ua = userAgent.toLowerCase();
-  if (ua.includes("firefox") || ua.includes("fxios")) {
+  if (isFirefoxUserAgent(ua)) {
     return "firefox";
   }
   if (ua.includes("edg/") || ua.includes("edga/") || ua.includes("edgios/")) {
@@ -123,7 +128,9 @@ export function detectAddressBarBrowser(
   return "chrome";
 }
 
-export function setupAddressBarSheet(): void {
+export function setupAddressBarSheet(
+  getFirefoxSuggestionConfig: () => FirefoxSuggestionConfig
+): { refreshSuggestionUrl: () => void } {
   const modal = $("#setup-modal");
   const openButton = $<HTMLButtonElement>("#open-setup");
   const closeButton = $<HTMLButtonElement>("#setup-close");
@@ -136,11 +143,21 @@ export function setupAddressBarSheet(): void {
   const browserSteps = $("#setup-browser-steps");
   const browserDocs = $<HTMLAnchorElement>("#setup-browser-docs");
   let tabButtons: HTMLButtonElement[] = [];
+  let activeBrowser: AddressBarBrowser | null = null;
 
   searchUrl.value = `${location.origin}?q=%s`;
   suggestUrl.value = `${location.origin}/suggest?q=%s`;
 
+  function refreshSuggestionUrl(): void {
+    suggestUrl.value =
+      activeBrowser === "firefox"
+        ? firefoxSuggestionUrl(location.origin, getFirefoxSuggestionConfig())
+        : `${location.origin}/suggest?q=%s`;
+  }
+
   function showBrowserGuide(browser: AddressBarBrowser): void {
+    activeBrowser = browser;
+    refreshSuggestionUrl();
     const guide = BROWSER_GUIDES[browser];
     for (const button of tabButtons) {
       const selected = button.dataset.browser === browser;
@@ -312,4 +329,6 @@ export function setupAddressBarSheet(): void {
     button.addEventListener("click", () => void copy(input, button));
     input.addEventListener("click", () => input.select());
   }
+
+  return { refreshSuggestionUrl };
 }

--- a/src/ui/home/command.ts
+++ b/src/ui/home/command.ts
@@ -1,4 +1,9 @@
 import {
+  DEFAULT_BANG_PREFIX,
+  DEFAULT_SNAP_PREFIX,
+  type TriggerPrefix,
+} from "../../shared/trigger-prefix";
+import {
   type BangMeta,
   createBangMeta,
   loadBuiltinBangCatalog,
@@ -18,6 +23,7 @@ function customDomain(url: string): string {
 export interface BangCommandController {
   input: HTMLInputElement;
   refresh: () => Promise<void>;
+  setPrefixes: (bang: TriggerPrefix, snap: TriggerPrefix) => void;
 }
 
 export function setupBangCommand(db: DB): BangCommandController {
@@ -27,12 +33,14 @@ export function setupBangCommand(db: DB): BangCommandController {
   const selectedBadgeText = $("#bang-command-selected-text");
   const results = $("#bang-command-results");
   const count = $("#home-bang-count");
-  const defaultPlaceholder = input.placeholder;
+  let bangPrefix = DEFAULT_BANG_PREFIX;
+  let snapPrefix = DEFAULT_SNAP_PREFIX;
+  let defaultPlaceholder = input.placeholder;
   let entries: readonly BangMeta[] | null = null;
   let loading: Promise<void> | null = null;
   let visible: BangMeta[] = [];
   let optionElements: HTMLButtonElement[] = [];
-  let selectedCommand: { marker: "!" | "@"; trigger: string } | null = null;
+  let selectedCommand: { marker: TriggerPrefix; trigger: string } | null = null;
   let selected = -1;
   let catalogVersion = 0;
 
@@ -47,7 +55,7 @@ export function setupBangCommand(db: DB): BangCommandController {
   }
 
   function commandParts(): {
-    marker: "!" | "@";
+    marker: TriggerPrefix;
     search: string;
     terms: string;
   } | null {
@@ -56,18 +64,18 @@ export function setupBangCommand(db: DB): BangCommandController {
       return null;
     }
     const leadingMarker = value.charAt(0);
-    if (leadingMarker === "!" || leadingMarker === "@") {
+    if (leadingMarker === bangPrefix || leadingMarker === snapPrefix) {
       const search = value.substring(1);
       return /\s/.test(search)
         ? null
         : { marker: leadingMarker, search: search.toLowerCase(), terms: "" };
     }
 
-    const bangIndex = value.lastIndexOf(" !");
-    const snapIndex = value.lastIndexOf(" @");
+    const bangIndex = value.lastIndexOf(` ${bangPrefix}`);
+    const snapIndex = value.lastIndexOf(` ${snapPrefix}`);
     const markerIndex = Math.max(bangIndex, snapIndex);
     if (markerIndex !== -1) {
-      const marker = value.charAt(markerIndex + 1) as "!" | "@";
+      const marker = value.charAt(markerIndex + 1) as TriggerPrefix;
       const search = value.substring(markerIndex + 2);
       return /\s/.test(search)
         ? null
@@ -79,7 +87,7 @@ export function setupBangCommand(db: DB): BangCommandController {
     }
 
     const search = value.toLowerCase().trim();
-    return /\s/.test(search) ? null : { marker: "!", search, terms: "" };
+    return /\s/.test(search) ? null : { marker: bangPrefix, search, terms: "" };
   }
 
   function renderSelection(previous = -1, scroll = true): void {
@@ -110,7 +118,7 @@ export function setupBangCommand(db: DB): BangCommandController {
     renderSelection(previous);
   }
 
-  function select(entry: BangMeta, marker: "!" | "@", terms: string): void {
+  function select(entry: BangMeta, marker: TriggerPrefix, terms: string): void {
     selectedCommand = { marker, trigger: entry.trigger };
     selectedBadgeText.textContent = `${marker}${entry.trigger}`;
     selectedBadge.setAttribute(
@@ -267,6 +275,18 @@ export function setupBangCommand(db: DB): BangCommandController {
     return loadEntries();
   }
 
+  function setPrefixes(bang: TriggerPrefix, snap: TriggerPrefix): void {
+    bangPrefix = bang;
+    snapPrefix = snap;
+    defaultPlaceholder = `Search bangs or enter ${bangPrefix}gh react`;
+    if (selectedCommand) {
+      clearSelectedCommand();
+    } else {
+      input.placeholder = defaultPlaceholder;
+      closeResults();
+    }
+  }
+
   input.addEventListener("focus", () => void loadEntries());
   input.addEventListener("blur", () => {
     setTimeout(() => {
@@ -350,5 +370,5 @@ export function setupBangCommand(db: DB): BangCommandController {
   } else {
     setTimeout(() => void loadEntries(), 800);
   }
-  return { input, refresh };
+  return { input, refresh, setPrefixes };
 }

--- a/src/ui/home/command.ts
+++ b/src/ui/home/command.ts
@@ -283,7 +283,11 @@ export function setupBangCommand(db: DB): BangCommandController {
       clearSelectedCommand();
     } else {
       input.placeholder = defaultPlaceholder;
-      closeResults();
+      if (entries && input.value.trim()) {
+        renderResults();
+      } else {
+        closeResults();
+      }
     }
   }
 

--- a/src/ui/home/index.html
+++ b/src/ui/home/index.html
@@ -663,8 +663,10 @@
           if (!sw) {
             return;
           }
+          const reloadOnActivation =
+            navigator.serviceWorker.controller !== null;
           sw.addEventListener("statechange", () => {
-            if (sw.state === "activated") {
+            if (sw.state === "activated" && reloadOnActivation) {
               location.reload();
             }
           });

--- a/src/ui/home/index.html
+++ b/src/ui/home/index.html
@@ -358,7 +358,11 @@
           <h3 class="section-title">Default Search Engine</h3>
           <div class="relative">
             <div class="flex gap-2 items-center">
-              <span class="text-text-secondary font-mono text-sm">!</span>
+              <span
+                id="default-bang-prefix"
+                class="text-text-secondary font-mono text-sm"
+                >!</span
+              >
               <input
                 type="text"
                 id="default-bang"
@@ -381,12 +385,37 @@
           </div>
         </section>
 
+        <!-- Shortcut Syntax -->
+        <section class="card mb-5">
+          <h3 class="section-title">Shortcut Syntax</h3>
+          <p class="label-text mb-2">
+            Choose different prefixes for bangs and snaps
+          </p>
+          <div class="grid grid-cols-2 gap-2">
+            <label class="label-text">
+              Bang prefix
+              <select
+                id="bang-prefix"
+                class="input-field mt-1 font-mono text-sm"
+              ></select>
+            </label>
+            <label class="label-text">
+              Snap prefix
+              <select
+                id="snap-prefix"
+                class="input-field mt-1 font-mono text-sm"
+              ></select>
+            </label>
+          </div>
+        </section>
+
         <!-- Feeling Lucky -->
         <section class="card mb-5">
           <h3 class="section-title">Feeling Lucky</h3>
           <p class="label-text mb-2">
-            Use <code>\query</code>, <code>query !</code>, or
-            <code>! query</code>
+            Use <code>\query</code>,
+            <code id="lucky-trailing-syntax">query !</code>, or
+            <code id="lucky-leading-syntax">! query</code>
             to jump to the first search result
           </p>
           <div class="relative">
@@ -499,8 +528,10 @@
                 aria-label="Suggestion providers"
               ></span>
             </span>
-            menu to see supported providers and choose another. Click the URL
-            below to copy it into Firefox's search engine settings.
+            menu to see supported providers and choose another. When the bang or
+            snap prefix differs from its default, the URL embeds both selected
+            prefixes. Click it to copy the complete configuration into Firefox's
+            search engine settings.
             <button
               type="button"
               id="suggest-firefox-url"

--- a/src/ui/home/index.ts
+++ b/src/ui/home/index.ts
@@ -1,11 +1,48 @@
+import {
+  DEFAULT_BANG_PREFIX,
+  DEFAULT_SNAP_PREFIX,
+  resolveTriggerPrefixes,
+  type TriggerPrefix,
+} from "../../shared/trigger-prefix";
 import type { DB } from "../db";
 import { setupAddressBarSheet } from "./address-bar-setup";
 import { setupBangCommand } from "./command";
 import { setupHomeShortcuts } from "./shortcuts";
 
-export function initHome(db: DB): () => Promise<void> {
-  const { input, refresh } = setupBangCommand(db);
+export interface HomeController {
+  refreshCatalog: () => Promise<void>;
+  setFirefoxSuggestProvider: (provider: string) => void;
+  setPrefixes: (bang: TriggerPrefix, snap: TriggerPrefix) => void;
+}
+
+export function initHome(db: DB): HomeController {
+  const {
+    input,
+    refresh,
+    setPrefixes: setCommandPrefixes,
+  } = setupBangCommand(db);
+  let bangPrefix = DEFAULT_BANG_PREFIX;
+  let snapPrefix = DEFAULT_SNAP_PREFIX;
+  let firefoxSuggestProvider = "google";
+  const addressBar = setupAddressBarSheet(() => ({
+    bangPrefix,
+    provider: firefoxSuggestProvider,
+    snapPrefix,
+  }));
+  const setPrefixes = (bang: TriggerPrefix, snap: TriggerPrefix) => {
+    bangPrefix = bang;
+    snapPrefix = snap;
+    setCommandPrefixes(bang, snap);
+    addressBar.refreshSuggestionUrl();
+  };
+  const setFirefoxSuggestProvider = (provider: string) => {
+    firefoxSuggestProvider = provider;
+    addressBar.refreshSuggestionUrl();
+  };
   setupHomeShortcuts(input);
-  setupAddressBarSheet();
-  return refresh;
+  void db.getMultipleSettings(["bang-prefix", "snap-prefix"]).then((values) => {
+    const [bang, snap] = resolveTriggerPrefixes(values[0], values[1]);
+    setPrefixes(bang, snap);
+  });
+  return { refreshCatalog: refresh, setFirefoxSuggestProvider, setPrefixes };
 }

--- a/src/ui/settings/custom-bangs.ts
+++ b/src/ui/settings/custom-bangs.ts
@@ -6,6 +6,10 @@ import {
 } from "../../shared/capture-template";
 import { validateCustomTrigger } from "../../shared/custom-trigger";
 import { validateSnapTarget } from "../../shared/snap-target";
+import {
+  DEFAULT_BANG_PREFIX,
+  type TriggerPrefix,
+} from "../../shared/trigger-prefix";
 import type { DB } from "../db";
 import { $, el } from "../dom";
 import { notifySW } from "../sw-bridge";
@@ -18,7 +22,8 @@ async function renderCustom(
   onEdit: (bang: CustomBangRecord) => void,
   onRemove: (trigger: string) => void,
   runWrite?: RunWrite,
-  isCurrent: () => boolean = () => true
+  isCurrent: () => boolean = () => true,
+  getBangPrefix: () => TriggerPrefix = () => DEFAULT_BANG_PREFIX
 ) {
   const custom = await db.getAllCustomBangs();
   if (!isCurrent()) {
@@ -52,13 +57,21 @@ async function renderCustom(
         }
         onRemove(b.trigger);
         notifySW("invalidate");
-        await renderCustom(db, onChange, onEdit, onRemove, runWrite, isCurrent);
+        await renderCustom(
+          db,
+          onChange,
+          onEdit,
+          onRemove,
+          runWrite,
+          isCurrent,
+          getBangPrefix
+        );
       });
       row.append(
         el(
           "code",
           "px-1.5 py-0.5 rounded bg-bg-active text-xs min-w-15 text-center font-mono",
-          `!${b.trigger}`
+          `${getBangPrefix()}${b.trigger}`
         ),
         el("span", "flex-1 text-[13px] font-medium", b.name),
         ...(b.regex
@@ -90,7 +103,8 @@ async function renderCustom(
 export function setupCustomBangs(
   db: DB,
   onChange?: (customBangs: CustomBangRecord[]) => void,
-  runWrite?: RunWrite
+  runWrite?: RunWrite,
+  getBangPrefix: () => TriggerPrefix = () => DEFAULT_BANG_PREFIX
 ) {
   const form = $<HTMLFormElement>("#add-bang-form");
   const shortcutInput = form.elements.namedItem("shortcut") as HTMLInputElement;
@@ -149,7 +163,8 @@ export function setupCustomBangs(
       editBang,
       removedBang,
       runWrite,
-      () => version === refreshVersion
+      () => version === refreshVersion,
+      getBangPrefix
     );
   };
 
@@ -159,8 +174,12 @@ export function setupCustomBangs(
   form.addEventListener("submit", async (e) => {
     e.preventDefault();
     const fd = new FormData(form);
-    const trigger = (fd.get("shortcut") as string)
-      .replace(/^!+/, "")
+    const rawTrigger = (fd.get("shortcut") as string).trim();
+    const trigger = (
+      rawTrigger.startsWith(getBangPrefix())
+        ? rawTrigger.substring(1)
+        : rawTrigger
+    )
       .toLowerCase()
       .trim();
     const name = (fd.get("name") as string).trim();

--- a/src/ui/settings/default-bang.ts
+++ b/src/ui/settings/default-bang.ts
@@ -1,4 +1,5 @@
 import type { CustomBangRecord } from "../../shared/capture-template";
+import type { TriggerPrefix } from "../../shared/trigger-prefix";
 import { flashAnim, shakeAnim } from "../animations";
 import {
   type BangMeta,
@@ -15,6 +16,7 @@ interface DefaultBangOptions {
   db: DB;
   initialCustom: readonly CustomBangRecord[];
   initialBang: string;
+  getBangPrefix: () => TriggerPrefix;
   onCommit: (trigger: string) => void;
   runWrite: RunWrite;
 }
@@ -26,6 +28,7 @@ export interface DefaultBangController {
 
 export async function setupDefaultBangSetting({
   db,
+  getBangPrefix,
   initialCustom,
   initialBang,
   onCommit,
@@ -136,7 +139,10 @@ export async function setupDefaultBangSetting({
 
   input.addEventListener("input", () => {
     clearTimeout(previewTimer);
-    const query = input.value.replace(/^!+/, "").trim().toLowerCase();
+    const raw = input.value.trim();
+    const query = (raw.startsWith(getBangPrefix()) ? raw.substring(1) : raw)
+      .trim()
+      .toLowerCase();
     if (!query) {
       closePreview();
       return;
@@ -169,7 +175,7 @@ export async function setupDefaultBangSetting({
             el(
               "code",
               "command-badge min-w-14 rounded-md px-2 py-0.5 text-center font-mono text-xs font-semibold",
-              `!${trigger}`
+              `${getBangPrefix()}${trigger}`
             ),
             el("span", "min-w-0 flex-1 truncate text-xs font-medium", name),
             el(
@@ -220,7 +226,10 @@ export async function setupDefaultBangSetting({
 
   input.addEventListener("change", () => {
     closePreview();
-    const value = input.value.replace(/^!+/, "").toLowerCase().trim();
+    const raw = input.value.trim();
+    const value = (raw.startsWith(getBangPrefix()) ? raw.substring(1) : raw)
+      .toLowerCase()
+      .trim();
     const bang = byTrigger.get(value);
     if (!bang) {
       shakeAnim(input);

--- a/src/ui/settings/firefox.ts
+++ b/src/ui/settings/firefox.ts
@@ -1,17 +1,26 @@
+import type { TriggerPrefix } from "../../shared/trigger-prefix";
 import { flashAnim } from "../animations";
 import { copyText } from "../clipboard";
 import { $, el } from "../dom";
+import { firefoxSuggestionUrl } from "../firefox-suggest";
 import type { SettingsWriter } from "./write";
 
 interface FirefoxSuggestionControls {
+  getPrefixes: () => readonly [TriggerPrefix, TriggerPrefix];
+  onProviderChange: (provider: string) => void;
   suggestSelect: HTMLSelectElement;
   suggestUrlInput: HTMLInputElement;
 }
 
 export function setupFirefoxSuggestions(
-  { suggestSelect, suggestUrlInput }: FirefoxSuggestionControls,
+  {
+    getPrefixes,
+    onProviderChange,
+    suggestSelect,
+    suggestUrlInput,
+  }: FirefoxSuggestionControls,
   writer: SettingsWriter
-): void {
+): { refresh: () => void } {
   const note = $("#suggest-firefox-note");
   const pickerWrap = $("#suggest-firefox-provider-picker-wrap");
   const picker = $<HTMLButtonElement>("#suggest-firefox-provider-picker");
@@ -22,7 +31,14 @@ export function setupFirefoxSuggestions(
   let menuHideTimer: ReturnType<typeof setTimeout>;
   let menuPinned = false;
 
-  const suggestionUrl = () => `${location.origin}/suggest?q=%s&sp=${provider}`;
+  const suggestionUrl = () => {
+    const [bangPrefix, snapPrefix] = getPrefixes();
+    return firefoxSuggestionUrl(location.origin, {
+      bangPrefix,
+      provider,
+      snapPrefix,
+    });
+  };
   const showMenu = () => {
     clearTimeout(menuHideTimer);
     menu.classList.remove("hidden");
@@ -39,7 +55,13 @@ export function setupFirefoxSuggestions(
       provider
     );
     label.textContent = provider;
-    url.replaceChildren(`${location.origin}/suggest?q=%s&sp=`, providerToken);
+    const value = suggestionUrl();
+    const providerStart = `${location.origin}/suggest?q=%s&sp=`.length;
+    url.replaceChildren(
+      value.substring(0, providerStart),
+      providerToken,
+      value.substring(providerStart + provider.length)
+    );
     for (const option of menu.children) {
       const selected = (option as HTMLElement).dataset.provider === provider;
       option.setAttribute("aria-selected", String(selected));
@@ -62,6 +84,7 @@ export function setupFirefoxSuggestions(
       button.setAttribute("role", "option");
       button.addEventListener("click", () => {
         provider = option.value;
+        onProviderChange(provider);
         menuPinned = false;
         renderUrl();
         hideMenu();
@@ -78,6 +101,7 @@ export function setupFirefoxSuggestions(
   note.classList.remove("hidden");
   writer.lock(suggestSelect);
   writer.lock(suggestUrlInput);
+  onProviderChange(provider);
   renderUrl();
 
   pickerWrap.addEventListener("pointerenter", () => {
@@ -135,4 +159,5 @@ export function setupFirefoxSuggestions(
     }
     setTimeout(renderUrl, 1500);
   });
+  return { refresh: renderUrl };
 }

--- a/src/ui/settings/index.ts
+++ b/src/ui/settings/index.ts
@@ -1,3 +1,7 @@
+import {
+  resolveTriggerPrefixes,
+  type TriggerPrefix,
+} from "../../shared/trigger-prefix";
 import { setSuggestCookie } from "../cookie";
 import type { DB } from "../db";
 import { $ } from "../dom";
@@ -6,6 +10,7 @@ import { notifySW } from "../sw-bridge";
 import { setupCustomBangs } from "./custom-bangs";
 import { setupDefaultBangSetting } from "./default-bang";
 import { getProviderControls, setupProviderSettings } from "./providers";
+import { setupSyntaxSettings } from "./syntax";
 import { setupSettingsTransfer } from "./transfer";
 import { createSettingsWriter, type SettingControl } from "./write";
 
@@ -15,22 +20,33 @@ const SETTINGS_KEYS = [
   "suggest-url",
   "lucky-provider",
   "lucky-url",
+  "bang-prefix",
+  "snap-prefix",
 ];
 
 export async function initSettings(
   db: DB,
   allowUnsafeCustomSuggestUrls = false,
-  onCatalogChange?: () => void
+  onCatalogChange?: () => void,
+  onSyntaxChange?: (bang: TriggerPrefix, snap: TriggerPrefix) => void,
+  onFirefoxSuggestProviderChange: (provider: string) => void = () => undefined
 ): Promise<void> {
   const defaultInput = $<HTMLInputElement>("#default-bang");
   const importFile = $<HTMLInputElement>("#import-file");
   const exportButton = $<HTMLButtonElement>("#export-btn");
+  const bangPrefixSelect = $<HTMLSelectElement>("#bang-prefix");
+  const snapPrefixSelect = $<HTMLSelectElement>("#snap-prefix");
   const providerControls = getProviderControls();
   const [rawSettings, initialCustom] = await Promise.all([
     db.getMultipleSettings(SETTINGS_KEYS),
     db.getAllCustomBangs(),
   ]);
+  const [bangPrefix, snapPrefix] = resolveTriggerPrefixes(
+    rawSettings[5],
+    rawSettings[6]
+  );
   const state = {
+    bangPrefix,
     custom: initialCustom.map((bang) => bang.trigger),
     defaultBang: rawSettings[0] || "g",
     suggestProvider: resolveSuggestProvider(
@@ -40,6 +56,7 @@ export async function initSettings(
     suggestUrl: rawSettings[2] || "",
     luckyProvider: rawSettings[3] || "default",
     luckyUrl: rawSettings[4] || "",
+    snapPrefix,
   };
 
   const customFormControls = Array.from(
@@ -58,6 +75,8 @@ export async function initSettings(
     providerControls.luckyUrlInput,
     importFile,
     exportButton,
+    bangPrefixSelect,
+    snapPrefixSelect,
     ...customFormControls,
   ]);
 
@@ -66,13 +85,28 @@ export async function initSettings(
       state.suggestProvider,
       state.defaultBang,
       state.suggestUrl,
-      state.custom
+      state.custom,
+      state.bangPrefix,
+      state.snapPrefix
     );
   };
   const providers = setupProviderSettings({
     controls: providerControls,
     db,
+    onFirefoxSuggestProviderChange,
     onSuggestChange: syncCookie,
+    state,
+    writer,
+  });
+  let refreshCustomBangs: () => Promise<void> = () => Promise.resolve();
+  const syntax = setupSyntaxSettings({
+    db,
+    onChange: () => {
+      syncCookie();
+      providers.refresh();
+      void refreshCustomBangs();
+      onSyntaxChange?.(state.bangPrefix, state.snapPrefix);
+    },
     state,
     writer,
   });
@@ -82,6 +116,7 @@ export async function initSettings(
     db,
     initialBang: state.defaultBang,
     initialCustom,
+    getBangPrefix: () => state.bangPrefix,
     onCommit: (trigger) => {
       state.defaultBang = trigger;
       syncCookie();
@@ -92,7 +127,7 @@ export async function initSettings(
   state.defaultBang = defaultBang.setCommitted(state.defaultBang);
   syncCookie();
   providers.updateDefaultDisplays();
-  const refreshCustomBangs = setupCustomBangs(
+  refreshCustomBangs = setupCustomBangs(
     db,
     (custom) => {
       state.custom = custom.map((bang) => bang.trigger);
@@ -100,7 +135,8 @@ export async function initSettings(
       syncCookie();
       onCatalogChange?.();
     },
-    writer.run
+    writer.run,
+    () => state.bangPrefix
   );
 
   setupSettingsTransfer({
@@ -117,12 +153,18 @@ export async function initSettings(
       state.suggestUrl = imported[2] || "";
       state.luckyProvider = imported[3] || "default";
       state.luckyUrl = imported[4] || "";
+      [state.bangPrefix, state.snapPrefix] = resolveTriggerPrefixes(
+        imported[5],
+        imported[6]
+      );
       await refreshCustomBangs();
       state.defaultBang = defaultBang.setCommitted(importedDefaultBang);
       providers.refresh();
+      syntax.refresh();
       writer.clearErrors();
       syncCookie();
       notifySW("invalidate");
+      onSyntaxChange?.(state.bangPrefix, state.snapPrefix);
     },
     runWrite: writer.run,
   });

--- a/src/ui/settings/providers.ts
+++ b/src/ui/settings/providers.ts
@@ -6,6 +6,7 @@ import {
 } from "../../shared/constants";
 import type { DB } from "../db";
 import { $ } from "../dom";
+import { isFirefoxUserAgent } from "../firefox-suggest";
 import { notifySW } from "../sw-bridge";
 import { setupFirefoxSuggestions } from "./firefox";
 import type { SettingsWriter } from "./write";
@@ -18,9 +19,11 @@ export interface ProviderControls {
 }
 
 export interface ProviderSettingsState {
+  bangPrefix: import("../../shared/trigger-prefix").TriggerPrefix;
   defaultBang: string;
   luckyProvider: string;
   luckyUrl: string;
+  snapPrefix: import("../../shared/trigger-prefix").TriggerPrefix;
   suggestProvider: string;
   suggestUrl: string;
 }
@@ -28,6 +31,7 @@ export interface ProviderSettingsState {
 interface ProviderSettingsOptions {
   controls: ProviderControls;
   db: DB;
+  onFirefoxSuggestProviderChange: (provider: string) => void;
   onSuggestChange: () => void;
   state: ProviderSettingsState;
   writer: SettingsWriter;
@@ -184,6 +188,7 @@ function setupProviderControl({
 export function setupProviderSettings({
   controls,
   db,
+  onFirefoxSuggestProviderChange,
   onSuggestChange,
   state,
   writer,
@@ -196,7 +201,8 @@ export function setupProviderSettings({
   const suggestDefaultDisplay = $("#suggest-default-display");
   const suggestDefaultPrefix = $("#suggest-default-prefix");
   const suggestDefaultProvider = $("#suggest-default-provider");
-  const isFirefox = /Firefox\//.test(navigator.userAgent);
+  const isFirefox = isFirefoxUserAgent(navigator.userAgent);
+  let refreshFirefoxSuggestions: (() => void) | null = null;
 
   function updateDefaultDisplays(): void {
     setDefaultDisplay(
@@ -242,11 +248,19 @@ export function setupProviderSettings({
     suggestControl.refresh(!isFirefox);
     luckyControl.refresh();
     updateDefaultDisplays();
+    refreshFirefoxSuggestions?.();
   }
 
   if (isFirefox) {
     state.suggestProvider = "google";
-    setupFirefoxSuggestions(controls, writer);
+    refreshFirefoxSuggestions = setupFirefoxSuggestions(
+      {
+        ...controls,
+        getPrefixes: () => [state.bangPrefix, state.snapPrefix],
+        onProviderChange: onFirefoxSuggestProviderChange,
+      },
+      writer
+    ).refresh;
   }
   refresh();
 

--- a/src/ui/settings/syntax.ts
+++ b/src/ui/settings/syntax.ts
@@ -1,0 +1,96 @@
+import {
+  TRIGGER_PREFIXES,
+  type TriggerPrefix,
+} from "../../shared/trigger-prefix";
+import type { DB } from "../db";
+import { $ } from "../dom";
+import { notifySW } from "../sw-bridge";
+import type { SettingsWriter } from "./write";
+
+export interface SyntaxSettingsState {
+  bangPrefix: TriggerPrefix;
+  snapPrefix: TriggerPrefix;
+}
+
+interface SyntaxSettingsOptions {
+  db: DB;
+  onChange: () => void;
+  state: SyntaxSettingsState;
+  writer: SettingsWriter;
+}
+
+export interface SyntaxSettingsController {
+  bangSelect: HTMLSelectElement;
+  refresh: () => void;
+  snapSelect: HTMLSelectElement;
+}
+
+function setOptions(select: HTMLSelectElement): void {
+  select.replaceChildren(
+    ...TRIGGER_PREFIXES.map((prefix) => {
+      const option = document.createElement("option");
+      option.value = prefix;
+      option.textContent = prefix;
+      return option;
+    })
+  );
+}
+
+export function setupSyntaxSettings({
+  db,
+  onChange,
+  state,
+  writer,
+}: SyntaxSettingsOptions): SyntaxSettingsController {
+  const bangSelect = $<HTMLSelectElement>("#bang-prefix");
+  const snapSelect = $<HTMLSelectElement>("#snap-prefix");
+  const defaultPrefix = $("#default-bang-prefix");
+  const luckyLeading = $("#lucky-leading-syntax");
+  const luckyTrailing = $("#lucky-trailing-syntax");
+  setOptions(bangSelect);
+  setOptions(snapSelect);
+
+  function refresh(): void {
+    bangSelect.value = state.bangPrefix;
+    snapSelect.value = state.snapPrefix;
+    for (const option of bangSelect.options) {
+      option.disabled = option.value === state.snapPrefix;
+    }
+    for (const option of snapSelect.options) {
+      option.disabled = option.value === state.bangPrefix;
+    }
+    defaultPrefix.textContent = state.bangPrefix;
+    luckyLeading.textContent = `${state.bangPrefix} query`;
+    luckyTrailing.textContent = `query ${state.bangPrefix}`;
+  }
+
+  function bind(
+    select: HTMLSelectElement,
+    key: "bang-prefix" | "snap-prefix",
+    stateKey: "bangPrefix" | "snapPrefix",
+    otherKey: "bangPrefix" | "snapPrefix"
+  ): void {
+    select.addEventListener("change", () => {
+      const value = select.value as TriggerPrefix;
+      if (!TRIGGER_PREFIXES.includes(value) || value === state[otherKey]) {
+        select.value = state[stateKey];
+        return;
+      }
+      void writer.run(() => db.setSetting(key, value), {
+        key,
+        onCommit: () => {
+          state[stateKey] = value;
+          refresh();
+          notifySW("invalidate");
+          onChange();
+        },
+        onFailure: refresh,
+      });
+    });
+  }
+
+  bind(bangSelect, "bang-prefix", "bangPrefix", "snapPrefix");
+  bind(snapSelect, "snap-prefix", "snapPrefix", "bangPrefix");
+  refresh();
+  return { bangSelect, refresh, snapSelect };
+}

--- a/tests/address-bar-setup.test.ts
+++ b/tests/address-bar-setup.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { firefoxSuggestionUrl } from "../src/ui/firefox-suggest";
 import { detectAddressBarBrowser } from "../src/ui/home/address-bar-setup";
 
 describe("address bar browser detection", () => {
@@ -18,11 +19,31 @@ describe("address bar browser detection", () => {
     expect(
       detectAddressBarBrowser("Mozilla/5.0 Version/17.5 Safari/605.1.15")
     ).toBe("safari");
+    expect(detectAddressBarBrowser("Mozilla/5.0 FxiOS/128.0")).toBe("firefox");
   });
 
   test("detects Edge on iOS", () => {
     expect(
       detectAddressBarBrowser("Mozilla/5.0 EdgiOS/126.0 Mobile/15E148")
     ).toBe("edge");
+  });
+});
+
+describe("Firefox suggestion URL", () => {
+  test("adds provider and only includes non-default syntax", () => {
+    expect(
+      firefoxSuggestionUrl("https://example.com", {
+        bangPrefix: "!",
+        provider: "google",
+        snapPrefix: "@",
+      })
+    ).toBe("https://example.com/suggest?q=%s&sp=google");
+    expect(
+      firefoxSuggestionUrl("https://example.com", {
+        bangPrefix: "$",
+        provider: "startpage",
+        snapPrefix: "~",
+      })
+    ).toBe("https://example.com/suggest?q=%s&sp=startpage&bp=%24&np=~");
   });
 });

--- a/tests/custom-trigger.test.ts
+++ b/tests/custom-trigger.test.ts
@@ -27,6 +27,9 @@ describe("custom trigger validation", () => {
       "two\twords",
       "foo!bar",
       "foo@bar",
+      "foo$bar",
+      "foo;bar",
+      "foo~bar",
       "foo+bar",
       "foo,bar",
       "foo:bar",
@@ -40,9 +43,13 @@ describe("custom trigger validation", () => {
       "foo%20bar",
       "foo%21bar",
       "foo%40bar",
+      "foo%24bar",
+      "foo%3Abar",
+      "foo%3bbar",
+      "foo%7Ebar",
       "foo%2fBAR%40baz",
     ]) {
-      expect(validateCustomTrigger(trigger)).toContain("encoded separators");
+      expect(validateCustomTrigger(trigger)).toContain("encoded spaces");
     }
   });
 

--- a/tests/e2e/flashbang.e2e.ts
+++ b/tests/e2e/flashbang.e2e.ts
@@ -2,6 +2,7 @@ import { readFile } from "node:fs/promises";
 import { expect, type Page, test } from "@playwright/test";
 import { DB_VERSION } from "../../src/shared/constants";
 import { encodeSuggestCookieValue } from "../../src/shared/suggest-cookie";
+import { SETTINGS_SCHEMA_VERSION } from "../../src/ui/db";
 
 const GOOGLE_REDIRECT = /google\.com\/search\?q=hello/;
 const GOOGLE_HOST = "https://www.google.com";
@@ -1044,7 +1045,7 @@ test("settings export includes its schema version", async ({ page }) => {
   expect(path).not.toBeNull();
   const exported = JSON.parse(await readFile(path as string, "utf8"));
 
-  expect(exported.schemaVersion).toBe(1);
+  expect(exported.schemaVersion).toBe(SETTINGS_SCHEMA_VERSION);
   expect(exported.settings).toBeTruthy();
   expect(exported.customBangs).toEqual([]);
 });

--- a/tests/e2e/flashbang.e2e.ts
+++ b/tests/e2e/flashbang.e2e.ts
@@ -313,13 +313,23 @@ test("Firefox locks cookie-backed suggestion settings", async ({ page }) => {
   await page
     .locator('#suggest-firefox-provider-menu [data-provider="startpage"]')
     .click();
-  const expectedUrl = `${origin}/suggest?q=%s&sp=startpage`;
+  let expectedUrl = `${origin}/suggest?q=%s&sp=startpage`;
   await expect(page.locator("#suggest-provider")).toHaveValue("google");
   await expect(page.locator("#suggest-firefox-url")).toHaveText(expectedUrl);
   await expect(page.locator("#suggest-firefox-url span")).toHaveText(
     "startpage"
   );
   await expect(providerPicker).toContainText("startpage");
+
+  let writeCount = await settingsWriteCount(page);
+  await page.selectOption("#bang-prefix", "$");
+  await waitForSettingsWrite(page, writeCount);
+  writeCount = await settingsWriteCount(page);
+  await page.selectOption("#snap-prefix", "~");
+  await waitForSettingsWrite(page, writeCount);
+  expectedUrl = `${origin}/suggest?q=%s&sp=startpage&bp=%24&np=~`;
+  await expect(page.locator("#suggest-firefox-url")).toHaveText(expectedUrl);
+
   await providerPicker.click();
   await expect(page.locator("#suggest-firefox-provider-menu")).toBeVisible();
   await providerPicker.click();
@@ -334,6 +344,10 @@ test("Firefox locks cookie-backed suggestion settings", async ({ page }) => {
       )
     )
     .toBe(expectedUrl);
+
+  await page.click("#modal-close");
+  await page.click("#open-setup");
+  await expect(page.locator("#setup-suggest-url")).toHaveValue(expectedUrl);
 });
 
 test("suggest endpoint rewrites malformed suggest cookie context", async ({
@@ -508,8 +522,9 @@ test("compact address-bar setup exposes browser instructions and copyable URLs",
   await expect(page.locator("#setup-search-url")).toHaveValue(
     `${new URL(page.url()).origin}?q=%s`
   );
+  const baseSuggestUrl = `${new URL(page.url()).origin}/suggest?q=%s`;
   await expect(page.locator("#setup-suggest-url")).toHaveValue(
-    `${new URL(page.url()).origin}/suggest?q=%s`
+    browserName === "firefox" ? `${baseSuggestUrl}&sp=google` : baseSuggestUrl
   );
   const expectedBrowser = {
     chromium: {
@@ -557,6 +572,7 @@ test("compact address-bar setup exposes browser instructions and copyable URLs",
   }
 
   await page.getByRole("tab", { name: "Edge" }).click();
+  await expect(page.locator("#setup-suggest-url")).toHaveValue(baseSuggestUrl);
   await expect(page.getByRole("tab", { name: "Edge" })).toHaveAttribute(
     "aria-selected",
     "true"
@@ -582,6 +598,9 @@ test("compact address-bar setup exposes browser instructions and copyable URLs",
   await expect(browserPanel).toHaveAttribute(
     "aria-labelledby",
     "setup-browser-tab-firefox"
+  );
+  await expect(page.locator("#setup-suggest-url")).toHaveValue(
+    `${baseSuggestUrl}&sp=google`
   );
 
   const cardBox = await page.locator("#setup-card").boundingBox();
@@ -741,6 +760,65 @@ test("settings invalidation applies a new default bang to redirects", async ({
   );
   expect(redirected.hostname).toBe("duckduckgo.com");
   expect(redirected.searchParams.get("q")).toBe("hello");
+});
+
+test("distinct configured prefixes replace bang, snap, lucky, and suggestion syntax", async ({
+  page,
+}) => {
+  await ensureWarmController(page);
+  await openSettingsModal(page);
+
+  await expect(page.locator("#bang-prefix")).toHaveValue("!");
+  await expect(page.locator("#snap-prefix")).toHaveValue("@");
+
+  let writeCount = await settingsWriteCount(page);
+  await page.selectOption("#bang-prefix", "$");
+  await waitForSettingsWrite(page, writeCount);
+  await expect(page.locator('#snap-prefix option[value="$"]')).toHaveAttribute(
+    "disabled",
+    ""
+  );
+
+  writeCount = await settingsWriteCount(page);
+  await page.selectOption("#snap-prefix", "~");
+  await waitForSettingsWrite(page, writeCount);
+  await expect(page.locator('#bang-prefix option[value="~"]')).toHaveAttribute(
+    "disabled",
+    ""
+  );
+  await expect(page.locator("#default-bang-prefix")).toHaveText("$");
+  await expect(page.locator("#lucky-leading-syntax")).toHaveText("$ query");
+  await expect(page.locator("#lucky-trailing-syntax")).toHaveText("query $");
+
+  const bang = new URL(await resolveRedirectViaWorker(page, "$g hello", true));
+  expect(bang.hostname).toBe("www.google.com");
+  expect(bang.searchParams.get("q")).toBe("hello");
+
+  const snap = new URL(await resolveRedirectViaWorker(page, "~g hello"));
+  expect(snap.searchParams.get("q")).toBe("hello site:google.com");
+
+  const replaced = new URL(await resolveRedirectViaWorker(page, "!g hello"));
+  expect(replaced.searchParams.get("q")).toBe("!g hello");
+
+  const lucky = new URL(await resolveRedirectViaWorker(page, "$ hello"));
+  expect(lucky.searchParams.get("q")).toBe("hello");
+  expect(lucky.searchParams.get("btnI")).toBe("1");
+
+  const suggestCookie = (await page.context().cookies()).find(
+    (cookie) => cookie.name === "suggest"
+  );
+  expect(suggestCookie?.value).toContain(",25");
+  const suggestionResponse = await page.request.get(
+    "/suggest?q=%24gh&bp=%24&np=~"
+  );
+  const suggestions = await suggestionResponse.json();
+  expect(suggestions[1].length).toBeGreaterThan(0);
+  expect(suggestions[1][0]).toMatch(/^\$g/);
+
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await page.click("#gear-btn");
+  await expect(page.locator("#bang-prefix")).toHaveValue("$");
+  await expect(page.locator("#snap-prefix")).toHaveValue("~");
 });
 
 test("default provider labels follow the selected bang", async ({

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -53,6 +53,27 @@ describe("handleSuggestRequest", () => {
     expect(payload[1]).toHaveLength(TOP_K);
   });
 
+  test("uses URL-backed Firefox syntax without cookies", async () => {
+    const bangResponse = await handleSuggestRequest(
+      req("http://localhost/suggest?q=%24gh&sp=google&bp=%24&np=~")
+    );
+    const [, bangCompletions] = await bangResponse.json();
+    expect(bangCompletions.length).toBeGreaterThan(0);
+    expect(
+      bangCompletions.every((value: string) => value.startsWith("$"))
+    ).toBe(true);
+
+    const snapResponse = await handleSuggestRequest(
+      req("http://localhost/suggest?q=~gh&sp=google&bp=%24&np=~")
+    );
+    const [, snapCompletions] = await snapResponse.json();
+    expect(snapCompletions.length).toBeGreaterThan(0);
+    expect(
+      snapCompletions.every((value: string) => value.startsWith("~"))
+    ).toBe(true);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
   test("blocks custom suggest provider request by default", async () => {
     const custom = "https://example.com/suggest?q={}";
     const response = await handleSuggestRequest(

--- a/tests/redirect-perf.test.ts
+++ b/tests/redirect-perf.test.ts
@@ -3,7 +3,11 @@ import { describe, expect, test } from "bun:test";
 import { compileCaptureUrl } from "../src/shared/capture-template";
 import { compileSnapTarget } from "../src/shared/snap-target";
 import type { UrlParts } from "../src/sw/redirect";
-import { type RedirectSettings, redirectRaw } from "../src/sw/redirect";
+import {
+  compileTriggerSyntax,
+  type RedirectSettings,
+  redirectRaw,
+} from "../src/sw/redirect";
 import { loadTestBangData } from "./helpers/bang-data";
 
 await loadTestBangData();
@@ -33,8 +37,7 @@ function settings(): RedirectSettings {
 const WARMUP = 10_000;
 const ITERS = 100_000;
 
-function benchRedirectRaw(raw: string): number {
-  const s = settings();
+function benchRedirectRaw(raw: string, s = settings()): number {
   for (let i = 0; i < WARMUP; i++) {
     redirectRaw(raw, s);
   }
@@ -90,6 +93,24 @@ describe("redirect performance regression", () => {
 
   test("custom snap target redirect stays under 0.005ms", () => {
     const ms = benchRedirectRaw("@docs+kittens");
+    expect(ms).toBeLessThan(0.005);
+  });
+
+  test("configured prefix bang redirect stays under 0.005ms", () => {
+    const s = {
+      ...settings(),
+      syntax: compileTriggerSyntax("$", "~"),
+    };
+    const ms = benchRedirectRaw("%24g+kittens+are+cute", s);
+    expect(ms).toBeLessThan(0.005);
+  });
+
+  test("configured prefix snap redirect stays under 0.005ms", () => {
+    const s = {
+      ...settings(),
+      syntax: compileTriggerSyntax("$", "~"),
+    };
+    const ms = benchRedirectRaw("~g+kittens", s);
     expect(ms).toBeLessThan(0.005);
   });
 });

--- a/tests/redirect.test.ts
+++ b/tests/redirect.test.ts
@@ -2,6 +2,11 @@ import { describe, expect, test } from "bun:test";
 import { compileCaptureUrl } from "../src/shared/capture-template";
 import { compileSnapTarget } from "../src/shared/snap-target";
 import {
+  TRIGGER_PREFIXES,
+  type TriggerPrefix,
+} from "../src/shared/trigger-prefix";
+import {
+  compileTriggerSyntax,
   type RedirectSettings,
   redirect,
   redirectRaw as redirectRawTuple,
@@ -129,6 +134,88 @@ describe("parse — bang syntax patterns", () => {
     const r = redirect("cats", settings());
     expect(r.status).toBe(302);
     expect(loc(r)).toBe("https://www.google.com/search?q=cats");
+  });
+});
+
+describe("parse — configurable bang and snap prefixes", () => {
+  function syntaxSettings(
+    bangPrefix: TriggerPrefix,
+    snapPrefix: TriggerPrefix
+  ): RedirectSettings {
+    return settings({
+      syntax: compileTriggerSyntax(bangPrefix, snapPrefix),
+    });
+  }
+
+  for (const bangPrefix of TRIGGER_PREFIXES) {
+    for (const snapPrefix of TRIGGER_PREFIXES) {
+      if (bangPrefix === snapPrefix) {
+        continue;
+      }
+      test(`${bangPrefix} bangs and ${snapPrefix} snaps match default syntax`, () => {
+        const customSyntax = syntaxSettings(bangPrefix, snapPrefix);
+        expect(loc(redirect(`${bangPrefix}g cats`, customSyntax))).toBe(
+          "https://www.google.com/search?q=cats"
+        );
+        expect(loc(redirect(`g${bangPrefix} cats`, customSyntax))).toBe(
+          "https://www.google.com/search?q=cats"
+        );
+        expect(loc(redirect(`cats ${bangPrefix}g`, customSyntax))).toBe(
+          "https://www.google.com/search?q=cats"
+        );
+        expect(loc(redirect(`cats g${bangPrefix}`, customSyntax))).toBe(
+          "https://www.google.com/search?q=cats"
+        );
+        expect(loc(redirect(`${snapPrefix}g cats`, customSyntax))).toBe(
+          "https://www.google.com/search?q=cats+site:google.com"
+        );
+        expect(loc(redirect(`cats ${snapPrefix}g`, customSyntax))).toBe(
+          "https://www.google.com/search?q=cats+site:google.com"
+        );
+      });
+    }
+  }
+
+  test("selected bang prefix controls bare lucky syntax", () => {
+    const customSyntax = syntaxSettings("$", "~");
+    expect(loc(redirect("$ cats", customSyntax))).toBe(
+      "https://www.google.com/search?btnI&q=cats"
+    );
+    expect(loc(redirect("cats $", customSyntax))).toBe(
+      "https://www.google.com/search?btnI&q=cats"
+    );
+    expect(loc(redirect("\\cats", customSyntax))).toBe(
+      "https://www.google.com/search?btnI&q=cats"
+    );
+    expect(loc(redirect("! cats", customSyntax))).toBe(
+      "https://www.google.com/search?q=!+cats"
+    );
+  });
+
+  test("replaced default prefixes remain ordinary query text", () => {
+    const customSyntax = syntaxSettings("$", "~");
+    expect(loc(redirect("!g cats", customSyntax))).toBe(
+      "https://www.google.com/search?q=!g+cats"
+    );
+    expect(loc(redirect("@g cats", customSyntax))).toBe(
+      "https://www.google.com/search?q=@g+cats"
+    );
+  });
+
+  test("percent-encoded configured prefixes resolve without decoding", () => {
+    const customSyntax = syntaxSettings("$", ";");
+    expect(loc(redirectRaw("%24g+cats", customSyntax))).toBe(
+      "https://www.google.com/search?q=cats"
+    );
+    expect(loc(redirectRaw("%3Bg+cats", customSyntax))).toBe(
+      "https://www.google.com/search?q=cats+site:google.com"
+    );
+    expect(loc(redirectRaw("cats+%24g", customSyntax))).toBe(
+      "https://www.google.com/search?q=cats"
+    );
+    expect(loc(redirectRaw("cats+%3bg", customSyntax))).toBe(
+      "https://www.google.com/search?q=cats+site:google.com"
+    );
   });
 });
 

--- a/tests/suggest.test.ts
+++ b/tests/suggest.test.ts
@@ -8,7 +8,11 @@ import {
   test,
 } from "bun:test";
 import { TOP_K } from "../src/shared/constants";
-import { readQueryParam, readTwoQueryParams } from "../src/shared/raw-query";
+import {
+  readQueryParam,
+  readSuggestQueryParams,
+  readTwoQueryParams,
+} from "../src/shared/raw-query";
 import { type BuildNode, buildRadixTrie } from "../src/shared/trie";
 
 interface TestBang {
@@ -196,7 +200,9 @@ function req(cookie?: string): Request {
 }
 
 const defaultSettings = {
+  bangPrefix: "!" as const,
   provider: "default",
+  snapPrefix: "@" as const,
   trigger: "g",
   customUrl: null,
   frecent: {},
@@ -207,7 +213,9 @@ describe("parseCookie", () => {
   test("no cookie → defaults", () => {
     const s = parseCookie(req());
     expect(s).toEqual({
+      bangPrefix: "!",
       provider: "default",
+      snapPrefix: "@",
       trigger: "g",
       customUrl: null,
       frecent: {},
@@ -218,7 +226,9 @@ describe("parseCookie", () => {
   test("all three fields parsed", () => {
     const s = parseCookie(req("suggest=google,ddg,https%3A%2F%2Fexample.com"));
     expect(s).toEqual({
+      bangPrefix: "!",
       provider: "google",
+      snapPrefix: "@",
       trigger: "ddg",
       customUrl: "https://example.com",
       frecent: {},
@@ -229,7 +239,9 @@ describe("parseCookie", () => {
   test("only provider and trigger, no customUrl", () => {
     const s = parseCookie(req("suggest=brave,g"));
     expect(s).toEqual({
+      bangPrefix: "!",
       provider: "brave",
+      snapPrefix: "@",
       trigger: "g",
       customUrl: null,
       frecent: {},
@@ -256,7 +268,9 @@ describe("parseCookie", () => {
   test("suggest cookie extracted among other cookies", () => {
     const s = parseCookie(req("theme=dark; suggest=bing,b; lang=en"));
     expect(s).toEqual({
+      bangPrefix: "!",
       provider: "bing",
+      snapPrefix: "@",
       trigger: "b",
       customUrl: null,
       frecent: {},
@@ -267,7 +281,9 @@ describe("parseCookie", () => {
   test("empty cookie value → defaults for missing fields", () => {
     const s = parseCookie(req("suggest="));
     expect(s).toEqual({
+      bangPrefix: "!",
       provider: "default",
+      snapPrefix: "@",
       trigger: "g",
       customUrl: null,
       frecent: {},
@@ -297,6 +313,20 @@ describe("parseCookie", () => {
     expect(s.customUrl).toBe("https://api.example.com/suggest?q={}");
     expect(s.frecent).toEqual({ mdn: 20, gh: 3 });
     expect(s.custom).toEqual(["my.site", "repo"]);
+  });
+
+  test("unified suggest format parses configured prefixes", () => {
+    const s = parseCookie(req("suggest=google,g,,45"));
+    expect(s.bangPrefix).toBe(";");
+    expect(s.snapPrefix).toBe("~");
+  });
+
+  test("invalid or equal configured prefixes fall back safely", () => {
+    for (const syntax of ["44", "99", "x", ""]) {
+      const s = parseCookie(req(`suggest=google,g,,${syntax}`));
+      expect(s.bangPrefix).toBe("!");
+      expect(s.snapPrefix).toBe("@");
+    }
   });
 
   test("backward compat: old cookie format without | parses identically", () => {
@@ -398,6 +428,15 @@ describe("parseSettings", () => {
     expect(s.provider).toBe("bing");
     expect(s.frecent).toEqual({});
     expect(s.trigger).toBe("ddg");
+  });
+
+  test("prefix query params override cookie syntax together", () => {
+    const s = parseSettings(
+      new URL("http://localhost/suggest?q=%24g&bp=%24&np=~"),
+      req("suggest=google,g,,01")
+    );
+    expect(s.bangPrefix).toBe("$");
+    expect(s.snapPrefix).toBe("~");
   });
 });
 
@@ -541,6 +580,24 @@ describe("readTwoQueryParams", () => {
         "sp"
       )
     ).toEqual(["first", "ddg"]);
+  });
+});
+
+describe("readSuggestQueryParams", () => {
+  test("reads provider and Firefox syntax overrides in one scan", () => {
+    expect(
+      readSuggestQueryParams(
+        "http://localhost/suggest?np=~&q=%24gh&x=1&bp=%24&sp=ddg"
+      )
+    ).toEqual(["$gh", "ddg", "$", "~"]);
+  });
+
+  test("returns first values and preserves missing overrides", () => {
+    expect(
+      readSuggestQueryParams(
+        "http://localhost/suggest?q=first&q=second&sp=ddg&sp=bing"
+      )
+    ).toEqual(["first", "ddg", null, null]);
   });
 });
 
@@ -1096,22 +1153,42 @@ describe("provider proxying — via suggest()", () => {
 describe("parsePartialBang — snap detection", () => {
   test('"@g" → prefix snap', () => {
     const result = parsePartialBang("@g");
-    expect(result).toEqual({ prefix: "", partial: "g", isSnap: true });
+    expect(result).toEqual({
+      prefix: "",
+      partial: "g",
+      isSnap: true,
+      triggerPrefix: "@",
+    });
   });
 
   test('"@gh" → prefix snap', () => {
     const result = parsePartialBang("@gh");
-    expect(result).toEqual({ prefix: "", partial: "gh", isSnap: true });
+    expect(result).toEqual({
+      prefix: "",
+      partial: "gh",
+      isSnap: true,
+      triggerPrefix: "@",
+    });
   });
 
   test('"cats @g" → suffix snap', () => {
     const result = parsePartialBang("cats @g");
-    expect(result).toEqual({ prefix: "cats ", partial: "g", isSnap: true });
+    expect(result).toEqual({
+      prefix: "cats ",
+      partial: "g",
+      isSnap: true,
+      triggerPrefix: "@",
+    });
   });
 
   test('"!g" → prefix bang, not snap', () => {
     const result = parsePartialBang("!g");
-    expect(result).toEqual({ prefix: "", partial: "g", isSnap: undefined });
+    expect(result).toEqual({
+      prefix: "",
+      partial: "g",
+      isSnap: undefined,
+      triggerPrefix: "!",
+    });
   });
 
   test('"cats !g" → suffix bang, not snap', () => {
@@ -1120,12 +1197,18 @@ describe("parsePartialBang — snap detection", () => {
       prefix: "cats ",
       partial: "g",
       isSnap: undefined,
+      triggerPrefix: "!",
     });
   });
 
   test('"@" → prefix snap with empty partial', () => {
     const result = parsePartialBang("@");
-    expect(result).toEqual({ prefix: "", partial: "", isSnap: true });
+    expect(result).toEqual({
+      prefix: "",
+      partial: "",
+      isSnap: true,
+      triggerPrefix: "@",
+    });
   });
 
   test('"@g cats" → has space after trigger, returns null', () => {
@@ -1134,6 +1217,23 @@ describe("parsePartialBang — snap detection", () => {
 
   test('"cats" → no trigger, returns null', () => {
     expect(parsePartialBang("cats")).toBeNull();
+  });
+
+  test("configured prefixes replace default bang and snap detection", () => {
+    expect(parsePartialBang("$gh", "$", "~")).toEqual({
+      prefix: "",
+      partial: "gh",
+      isSnap: undefined,
+      triggerPrefix: "$",
+    });
+    expect(parsePartialBang("cats ~gh", "$", "~")).toEqual({
+      prefix: "cats ",
+      partial: "gh",
+      isSnap: true,
+      triggerPrefix: "~",
+    });
+    expect(parsePartialBang("!gh", "$", "~")).toBeNull();
+    expect(parsePartialBang("@gh", "$", "~")).toBeNull();
   });
 });
 
@@ -1155,6 +1255,30 @@ describe("snap suggestions — via suggest()", () => {
       expect(completion.startsWith("@")).toBe(true);
       expect(completion.startsWith("!")).toBe(false);
     }
+  });
+
+  test("configured prefixes replace completion syntax", async () => {
+    const bangResponse = await suggest("$gh", {
+      ...defaultSettings,
+      bangPrefix: "$",
+      snapPrefix: "~",
+    });
+    const [, bangCompletions] = await bangResponse.json();
+    expect(bangCompletions.length).toBeGreaterThan(0);
+    expect(
+      bangCompletions.every((value: string) => value.startsWith("$"))
+    ).toBe(true);
+
+    const snapResponse = await suggest("~gh", {
+      ...defaultSettings,
+      bangPrefix: "$",
+      snapPrefix: "~",
+    });
+    const [, snapCompletions] = await snapResponse.json();
+    expect(snapCompletions.length).toBeGreaterThan(0);
+    expect(
+      snapCompletions.every((value: string) => value.startsWith("~"))
+    ).toBe(true);
   });
 
   test('"cats @gh" keeps the leading query prefix with @ completions', async () => {

--- a/tests/sw-idb.test.ts
+++ b/tests/sw-idb.test.ts
@@ -84,6 +84,41 @@ describe("sw/idb redirect settings", () => {
     ]);
   });
 
+  test("precompiles distinct bang and snap prefixes while loading settings", async () => {
+    await seedDb({
+      settings: [
+        { key: "bang-prefix", value: "$" },
+        { key: "snap-prefix", value: "~" },
+      ],
+    });
+
+    const settings = await (await loadSwIdb()).readRedirectSettings();
+    expect(settings.syntax).toBeDefined();
+    expect(redirectUrl("$g cats", settings)).toContain(
+      "google.com/search?q=cats"
+    );
+    expect(redirectUrl("~g cats", settings)).toContain(
+      "google.com/search?q=cats+site:google.com"
+    );
+    expect(redirectUrl("!g cats", settings)).toContain("q=!g+cats");
+    expect(redirectUrl("@g cats", settings)).toContain("q=@g+cats");
+  });
+
+  test("falls back to default syntax for equal persisted prefixes", async () => {
+    await seedDb({
+      settings: [
+        { key: "bang-prefix", value: "$" },
+        { key: "snap-prefix", value: "$" },
+      ],
+    });
+
+    const settings = await (await loadSwIdb()).readRedirectSettings();
+    expect(settings.syntax).toBeUndefined();
+    expect(redirectUrl("!g cats", settings)).toContain(
+      "google.com/search?q=cats"
+    );
+  });
+
   test("resolves a user custom bang as the default", async () => {
     await seedDb({
       settings: [{ key: "default-bang", value: "mydocs" }],

--- a/tests/trigger-prefix.test.ts
+++ b/tests/trigger-prefix.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import {
+  decodeTriggerPrefixes,
+  encodeTriggerPrefixes,
+  isTriggerPrefix,
+  resolveTriggerPrefixes,
+  TRIGGER_PREFIXES,
+} from "../src/shared/trigger-prefix";
+
+describe("trigger prefix settings", () => {
+  test("accepts exactly the supported prefix set", () => {
+    for (const prefix of TRIGGER_PREFIXES) {
+      expect(isTriggerPrefix(prefix)).toBe(true);
+    }
+    for (const value of ["", "#", "+", "ab", null, undefined]) {
+      expect(isTriggerPrefix(value)).toBe(false);
+    }
+  });
+
+  test("round-trips every distinct prefix pair compactly", () => {
+    for (const bang of TRIGGER_PREFIXES) {
+      for (const snap of TRIGGER_PREFIXES) {
+        if (bang === snap) {
+          continue;
+        }
+        const encoded = encodeTriggerPrefixes(bang, snap);
+        expect(encoded).toHaveLength(2);
+        expect(decodeTriggerPrefixes(encoded)).toEqual([bang, snap]);
+      }
+    }
+  });
+
+  test("falls back for invalid or equal persisted values", () => {
+    expect(resolveTriggerPrefixes("$", "~")).toEqual(["$", "~"]);
+    expect(resolveTriggerPrefixes("$", "$")).toEqual(["!", "@"]);
+    expect(resolveTriggerPrefixes("#", "~")).toEqual(["!", "~"]);
+    expect(decodeTriggerPrefixes("44")).toBeNull();
+    expect(decodeTriggerPrefixes("99")).toBeNull();
+  });
+});

--- a/tests/ui-db.test.ts
+++ b/tests/ui-db.test.ts
@@ -105,7 +105,7 @@ describe("custom bang import and export", () => {
     expect(await db.getSetting("frecency")).toBe("123|g:5,ddg:2");
   });
 
-  test("round-trips schema-v1 exports with custom provider URLs", async () => {
+  test("round-trips current-schema exports with custom provider URLs", async () => {
     const db = new DB();
     await db.setSetting("default-bang", "ddg");
     await db.setSetting("suggest-provider", "custom");
@@ -136,6 +136,41 @@ describe("custom bang import and export", () => {
     ]);
   });
 
+  test("round-trips distinct bang and snap prefixes", async () => {
+    const db = new DB();
+    await db.setSetting("bang-prefix", "$");
+    await db.setSetting("snap-prefix", "~");
+
+    const exported = await db.exportAll();
+    await db.setSetting("bang-prefix", "!");
+    await db.setSetting("snap-prefix", "@");
+    await db.importAll(exported);
+
+    expect(
+      await db.getMultipleSettings(["bang-prefix", "snap-prefix"])
+    ).toEqual(["$", "~"]);
+  });
+
+  test("rejects invalid or equal imported prefixes before replacing data", async () => {
+    const db = new DB();
+    await db.setSetting("default-bang", "ddg");
+
+    for (const settings of [
+      { bangPrefix: "#", snapPrefix: "@" },
+      { bangPrefix: "$", snapPrefix: "$" },
+    ]) {
+      await expect(
+        db.importAll({
+          schemaVersion: SETTINGS_SCHEMA_VERSION,
+          settings,
+          customBangs: [],
+        })
+      ).rejects.toThrow();
+    }
+
+    expect(await db.getSetting("default-bang")).toBe("ddg");
+  });
+
   test("round-trips legacy exports with custom provider URLs", async () => {
     const db = new DB();
     const legacy = {
@@ -154,7 +189,11 @@ describe("custom bang import and export", () => {
     const exported = await db.exportAll();
 
     expect(result.replaced).toBe(true);
-    expect(exported.settings).toEqual(legacy.settings);
+    expect(exported.settings).toEqual({
+      ...legacy.settings,
+      bangPrefix: null,
+      snapPrefix: null,
+    });
   });
 
   test("refuses to export malformed legacy custom settings", async () => {


### PR DESCRIPTION
## Summary
- add distinct configurable bang and snap prefixes with `!`/`@` defaults and support for `!`, `@`, `$`, `:`, `;`, and `~`
- persist syntax through IndexedDB, cookies, import/export, redirects, suggestions, homepage controls, and exhaustive pair coverage
- carry Firefox suggestion provider settings in the registered URL and append `bp`/`np` only for non-default syntax; keep Settings and Use from address bar URLs synchronized
- preserve redirect performance with packed marker metadata, specialized snap handling, and allocation-conscious query/cookie parsing

## Performance
Compared with clean `master` using 12 measured quick-profile runs:
- prefix bang: 245 ns -> 245 ns
- default search: 207 ns -> 203 ns
- prefix snap: 271 ns -> 278 ns
- suffix snap: 325 ns -> 338 ns
- built-in capture: 693 ns -> 687 ns
- bang suggestion handler: 1.87 us -> 1.87 us
- core suggestions: 1.66 us -> 1.64 us
- warm plain-to-bang first hit: 409 us -> 368 us

## Verification
- `bun run check`
- `bun run typecheck`
- `bun test` (432 passing)
- `bun run build`
- focused Chromium E2E: Firefox settings URL and address-bar setup
- focused Firefox E2E: address-bar setup and configured syntax redirects

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable bang and snap shortcut prefixes, with live updates across search, snap, lucky-search, custom bang, and settings interfaces.
  * Added Firefox suggestion URLs that preserve custom provider and shortcut-prefix settings.
  * Added support for importing and exporting shortcut-prefix settings.

* **Bug Fixes**
  * Improved suggestion URL parsing and handling of custom syntax without relying on cookies.

* **Documentation**
  * Updated setup, privacy, browser behavior, syntax, and suggestion URL documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->