### PR TITLE
fix(ui): clarify configurable syntax guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ All three support bangs natively — but every query still round-trips through t
 
 Settings lets you select different prefixes for bangs and snaps from `!`, `@`, `$`, `:`, `;`, and `~`. Changing a prefix replaces that syntax rather than adding an alias. For example, with `$` for bangs and `~` for snaps, use `$gh react`, `react $gh`, `~w quantum`, and `quantum ~w`; `!gh` and `@w` become ordinary search text. The examples below use the default `!` and `@` prefixes.
 
+Firefox-based browsers do not reliably show remote suggestions when address-bar input begins with `:`. A prefix snap such as `:gh` may have no suggestion dropdown even though a query-first snap such as `test :gh` does. Prefer `@` or `~` for snaps if you want prefix autocomplete in Firefox, Zen, or LibreWolf.
+
 ## Bang syntax
 
 Flashbang supports 4 formats. All bangs are case-insensitive.

--- a/src/ui/home/index.html
+++ b/src/ui/home/index.html
@@ -413,9 +413,21 @@
         <section class="card mb-5">
           <h3 class="section-title">Feeling Lucky</h3>
           <p class="label-text mb-2">
-            Use <code>\query</code>,
-            <code id="lucky-trailing-syntax">query !</code>, or
-            <code id="lucky-leading-syntax">! query</code>
+            Use
+            <code
+              class="rounded bg-bg-active px-1.5 py-0.5 font-mono text-xs text-text"
+              >\query</code
+            >,
+            <code
+              id="lucky-trailing-syntax"
+              class="rounded bg-bg-active px-1.5 py-0.5 font-mono text-xs text-text"
+              >query !</code
+            >, or
+            <code
+              id="lucky-leading-syntax"
+              class="rounded bg-bg-active px-1.5 py-0.5 font-mono text-xs text-text"
+              >! query</code
+            >
             to jump to the first search result
           </p>
           <div class="relative">


### PR DESCRIPTION
## Summary
- warn Firefox-family users that leading colon prefixes may not show remote suggestions
- style Feeling Lucky syntax examples as distinct inline-code tokens

## Validation
- bun run check
- bun test tests/development-docs.test.ts
- bun run build
- focused Chromium configurable-prefix E2E