### PR TITLE
chore: release v1.5.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "flashbang",
   "description": "The sub-1ms local first duck-duck-go style bang redirects",
   "private": true,
-  "version": "1.5.5",
+  "version": "1.5.6",
   "type": "module",
   "packageManager": "bun@1.3.14",
   "scripts": {

--- a/src/ui/home/index.ts
+++ b/src/ui/home/index.ts
@@ -39,7 +39,7 @@ export function initHome(db: DB): HomeController {
     firefoxSuggestProvider = provider;
     addressBar.refreshSuggestionUrl();
   };
-  setupHomeShortcuts(input);
+  setupHomeShortcuts(input, () => [bangPrefix, snapPrefix]);
   void db.getMultipleSettings(["bang-prefix", "snap-prefix"]).then((values) => {
     const [bang, snap] = resolveTriggerPrefixes(values[0], values[1]);
     setPrefixes(bang, snap);

--- a/src/ui/home/shortcuts.ts
+++ b/src/ui/home/shortcuts.ts
@@ -1,4 +1,9 @@
-export function setupHomeShortcuts(input: HTMLInputElement): void {
+import type { TriggerPrefix } from "../../shared/trigger-prefix";
+
+export function setupHomeShortcuts(
+  input: HTMLInputElement,
+  getPrefixes: () => readonly [TriggerPrefix, TriggerPrefix]
+): void {
   let awaitingInputKey = false;
   let inputKeyTimer = 0;
 
@@ -19,6 +24,20 @@ export function setupHomeShortcuts(input: HTMLInputElement): void {
     }
     awaitingInputKey = false;
     window.clearTimeout(inputKeyTimer);
+    const [bangPrefix, snapPrefix] = getPrefixes();
+    if (
+      !typing &&
+      unmodified &&
+      (event.key === bangPrefix || event.key === snapPrefix)
+    ) {
+      event.preventDefault();
+      input.focus();
+      const start = input.selectionStart ?? input.value.length;
+      const end = input.selectionEnd ?? input.value.length;
+      input.setRangeText(event.key, start, end, "end");
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+      return;
+    }
     if (!typing && unmodified && key === "g" && !event.repeat) {
       awaitingInputKey = true;
       inputKeyTimer = window.setTimeout(() => {

--- a/tests/e2e/flashbang.e2e.ts
+++ b/tests/e2e/flashbang.e2e.ts
@@ -791,6 +791,17 @@ test("distinct configured prefixes replace bang, snap, lucky, and suggestion syn
   await expect(page.locator("#lucky-leading-syntax")).toHaveText("$ query");
   await expect(page.locator("#lucky-trailing-syntax")).toHaveText("query $");
 
+  await page.click("#modal-close");
+  const commandInput = page.locator("#bang-command-input");
+  await page.keyboard.press("$");
+  await expect(commandInput).toBeFocused();
+  await expect(commandInput).toHaveValue("$");
+  await commandInput.fill("");
+  await commandInput.evaluate((element) => element.blur());
+  await page.keyboard.press("~");
+  await expect(commandInput).toBeFocused();
+  await expect(commandInput).toHaveValue("~");
+
   const bang = new URL(await resolveRedirectViaWorker(page, "$g hello", true));
   expect(bang.hostname).toBe("www.google.com");
   expect(bang.searchParams.get("q")).toBe("hello");


### PR DESCRIPTION
## Summary

- focus the home command input and insert the selected bang or snap prefix when that key is pressed outside a form control
- preserve the live configured prefix pair in the global home keyboard shortcuts
- bump the package version to 1.5.6
- release all configurable syntax and runtime performance work merged since v1.5.5

## Validation

- `bun run codegen -- --from-merged`
- `bun run typecheck`
- `bun run check`
- `bun audit`
- `bun test` (432 passed)
- `bun run build`
- `E2E_PORT=54322 bun run test:e2e` (105 passed, 4 expected skips)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Configured bang and snap prefixes now work reliably from keyboard shortcuts.
  - Pressing a configured prefix focuses the command input and inserts the prefix automatically.
  - Existing text selections are replaced when inserting a shortcut prefix.

- **Bug Fixes**
  - Updated shortcuts now use the latest configured prefix values.

- **Chores**
  - Incremented the package version to 1.5.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->