### PR TITLE
perf(sw): decode bang URLs lazily

### DIFF
--- a/scripts/codegen.ts
+++ b/scripts/codegen.ts
@@ -654,8 +654,25 @@ function generateBinary(bangs: readonly Bang[]): Uint8Array {
     packed.triggerLensKind === "u8"
       ? Uint8Array.from(triggerBlob.lengths)
       : Uint16Array.from(triggerBlob.lengths);
-  const prefixLengths = Uint16Array.from(packed.prefixBlob.lengths);
-  const suffixLengths = Uint16Array.from(packed.suffixBlob.lengths);
+  // URL blobs stay byte-backed in the worker and are decoded one entry at a time.
+  const prefixLengths = Uint16Array.from(packed.uniquePrefixes, (value) => {
+    const length = encoder.encode(value).byteLength;
+    if (length > 0xffff) {
+      throw new Error(
+        `Binary bang format requires encoded prefix length <= 65535, got ${length}`
+      );
+    }
+    return length;
+  });
+  const suffixLengths = Uint16Array.from(packed.uniqueSuffixes, (value) => {
+    const length = encoder.encode(value).byteLength;
+    if (length > 0xffff) {
+      throw new Error(
+        `Binary bang format requires encoded suffix length <= 65535, got ${length}`
+      );
+    }
+    return length;
+  });
   const prefixIds = Uint16Array.from(reorderedPrefixIds);
   const suffixIds = Uint16Array.from(reorderedSuffixIds);
 
@@ -677,7 +694,7 @@ function generateBinary(bangs: readonly Bang[]): Uint8Array {
   const output = new Uint8Array(new ArrayBuffer(totalBytes));
   new Uint32Array(output.buffer, 0, headerWords).set([
     0x31424246,
-    2,
+    3,
     packed.entryCount,
     mph.displacements.length,
     packed.triggerLensKind === "u8" ? 1 : 2,

--- a/src/sw/bang-data.ts
+++ b/src/sw/bang-data.ts
@@ -1,7 +1,8 @@
 export type BuiltinUrlParts = readonly [string, string | null];
 
 const MAGIC = 0x31424246;
-const VERSION = 2;
+// Version 3 stores prefix/suffix lengths as UTF-8 bytes for lazy decoding.
+const VERSION = 3;
 const HEADER_WORDS = 13;
 const HEADER_BYTES = HEADER_WORDS * Uint32Array.BYTES_PER_ELEMENT;
 const MPH_SLOT_MULTIPLIER = 0x85ebca6b;
@@ -80,9 +81,9 @@ export function initializeBangData(buffer: ArrayBuffer): void {
   const decoder = new TextDecoder();
   const triggerBlob = decoder.decode(new Uint8Array(buffer, offset, header[7]));
   offset += header[7];
-  const prefixBlob = decoder.decode(new Uint8Array(buffer, offset, header[8]));
+  const prefixBlob = new Uint8Array(buffer, offset, header[8]);
   offset += header[8];
-  const suffixBlob = decoder.decode(new Uint8Array(buffer, offset, header[9]));
+  const suffixBlob = new Uint8Array(buffer, offset, header[9]);
 
   const triggerOffsets = offsets(triggerLengths);
   const prefixOffsets = offsets(prefixLengths);
@@ -95,7 +96,9 @@ export function initializeBangData(buffer: ArrayBuffer): void {
   function prefix(id: number): string {
     let value = prefixCache[id];
     if (value === undefined) {
-      value = prefixBlob.substring(prefixOffsets[id], prefixOffsets[id + 1]);
+      value = decoder.decode(
+        prefixBlob.subarray(prefixOffsets[id], prefixOffsets[id + 1])
+      );
       prefixCache[id] = value;
     }
     return value;
@@ -104,7 +107,10 @@ export function initializeBangData(buffer: ArrayBuffer): void {
   function suffix(id: number): string {
     let value = suffixCache[id];
     if (value === undefined) {
-      value = suffixBlob.substring(suffixOffsets[id], suffixOffsets[id + 1]);
+      const start = suffixOffsets[id];
+      const end = suffixOffsets[id + 1];
+      value =
+        start === end ? "" : decoder.decode(suffixBlob.subarray(start, end));
       suffixCache[id] = value;
     }
     return value;

--- a/tests/codegen-roundtrip.test.ts
+++ b/tests/codegen-roundtrip.test.ts
@@ -81,7 +81,7 @@ describe("codegen round-trip", () => {
     const binary = await Bun.file("src/generated/bangs.bin").arrayBuffer();
     const header = new Uint32Array(binary, 0, 13);
     expect(header[0]).toBe(0x31424246);
-    expect(header[1]).toBe(2);
+    expect(header[1]).toBe(3);
     expect(header[2]).toBe(bangs.filter((bang) => !bang.regex).length);
     expect(header[11]).toBe(binary.byteLength);
     expect(header[3] & (header[3] - 1)).toBe(0);


### PR DESCRIPTION
## Summary
- store v3 URL prefix and suffix lengths as UTF-8 byte lengths
- keep URL blobs byte-backed and decode only matched URL parts
- skip decoding zero-length suffixes

## Results
- avoids about 1.06 MB of eager URL-string allocation per service-worker lifetime
- keeps the 724,617-byte binary size unchanged
- retains effectively unchanged warm lookup performance

## Validation
- bun test (432 passed)
- bun run typecheck
- bun run check
- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of non-ASCII characters in bang prefixes and suffixes.
  * Reduced unnecessary decoding during bang lookups, improving efficiency while preserving existing behavior.
  * Added validation to prevent oversized encoded prefix or suffix data from producing invalid lookup artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->