### PR TITLE
chore(release): prepare v1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "flashbang",
   "description": "The sub-1ms local first duck-duck-go style bang redirects",
   "private": true,
-  "version": "1.5.6",
+  "version": "1.6.0",
   "type": "module",
   "packageManager": "bun@1.3.14",
   "scripts": {

--- a/tests/suggest.test.ts
+++ b/tests/suggest.test.ts
@@ -1387,10 +1387,18 @@ describe("snap suggestions — via suggest()", () => {
   });
 
   test("already-selected triggers are omitted from chain suggestions", async () => {
-    const r = await suggest("@gh,so,g", defaultSettings);
+    const settings = {
+      ...defaultSettings,
+      frecent: { gh: 200 },
+    };
+    const baseline = await suggest("@g", settings);
+    const [, baselineCompletions] = await baseline.json();
+    expect(baselineCompletions).toContain("@gh");
+
+    const r = await suggest("@gh,so,g", settings);
     const [, completions] = await r.json();
     expect(completions).not.toContain("@gh,so,gh");
-    expect(completions).toContain("@gh,so,ghi");
+    expect(completions.length).toBeGreaterThan(0);
   });
 
   test("custom triggers complete snap-chain segments", async () => {


### PR DESCRIPTION
## Summary

- bump the package version to 1.6.0
- make the snap-chain exclusion regression test independent of generated catalog ranking

## Validation

- `bun run check`
- `bun run typecheck`
- `bun test` (476 passed)
- `bun run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved snap-chain suggestions to omit triggers that have already been selected.
  * Updated suggestion behavior validation for more accurate completion results.

* **Chores**
  * Updated the package version to 1.6.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->