### PR TITLE
fix(setup): stop promoting the private search URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,12 +123,11 @@ https://flashbang.tech/suggest?q=%s&sp=ddg&bp=%24&np=~
 A public instance is available at **[flashbang.tech](https://flashbang.tech)**. Just visit it, then add it as a custom search engine in your browser:
 
 - **Search URL:** `https://flashbang.tech?q=%s`
-- **Private Search URL:** `https://flashbang.tech/#q=%s` (slightly slower; keeps submitted query text out of search-navigation requests to the Flashbang host)
 - **Suggestion URL:** `https://flashbang.tech/suggest?q=%s` (Optional)
 
 Nothing to build or deploy.
 
-The private template stores the query in the URL fragment, which browsers do not send in HTTP requests. An installed Service Worker serves a purpose-built bootstrap directly from memory; the page passes the still-encoded fragment directly to the worker, then replaces the transient history entry with the destination. When a worker is not yet installed, the page resolves the first query and transfers its bang-data buffer and compiled redirect settings to the registering worker before navigating. The normal `?q=%s` template remains the fastest option because the Service Worker can intercept it before any page loads. Search suggestions are separate network requests; leave the Suggestions URL unset if you do not want address-bar input sent to the configured suggestion provider through Flashbang.
+For the privacy-sensitive case where query text must remain on your device until navigation to the destination, use `https://flashbang.tech/#q=%s` and leave the Suggestion URL unset. This fragment-based option is significantly slower and is not recommended for normal use. Search suggestions are separate network requests; leaving the Suggestion URL unset keeps address-bar input from being sent to the configured suggestion provider through Flashbang.
 
 ### Browser quirks
 

--- a/src/ui/home/address-bar-setup.ts
+++ b/src/ui/home/address-bar-setup.ts
@@ -43,7 +43,7 @@ const BROWSER_GUIDES: Record<AddressBarBrowser, BrowserGuide> = {
     steps: [
       "Select Manage Search Engines.",
       "If flashbang appears under Inactive Shortcuts, select Activate.",
-      "Otherwise select Add and enter Search Engine: flashbang, Keyword: f (or another shortcut), and URL with %s in place of query: paste either Search URL from above.",
+      "Otherwise select Add and enter Search Engine: flashbang, Keyword: f (or another shortcut), and URL with %s in place of query: paste the Search URL from above.",
       "In Search Engines, open flashbang's three-dot menu and select Make default.",
     ],
     docsUrl:
@@ -56,7 +56,7 @@ const BROWSER_GUIDES: Record<AddressBarBrowser, BrowserGuide> = {
     steps: [
       "Under Site search, check Inactive shortcuts. If flashbang appears, select Activate.",
       "If it was not indexed automatically, select Add.",
-      "Enter Search engine: flashbang, Shortcut: f (or another shortcut), and URL with %s in place of query: paste either Search URL from above.",
+      "Enter Search engine: flashbang, Shortcut: f (or another shortcut), and URL with %s in place of query: paste the Search URL from above.",
       "Open flashbang's More menu and select Make default.",
     ],
     docsUrl:
@@ -85,7 +85,7 @@ const BROWSER_GUIDES: Record<AddressBarBrowser, BrowserGuide> = {
     settingsUrl: "about:preferences#search",
     steps: [
       "Under Search Shortcuts, select Add.",
-      "Enter flashbang as the Search engine name and paste either Search URL above into Engine URL.",
+      "Enter flashbang as the Search engine name and paste the Search URL above into Engine URL.",
       "Optional: paste the Suggestions URL above into Search suggestion API URL to enable address-bar autocomplete, then save.",
       "Choose flashbang under Default Search Engine.",
     ],
@@ -136,7 +136,6 @@ export function setupAddressBarSheet(
   const closeButton = $<HTMLButtonElement>("#setup-close");
   const status = $("#setup-copy-status");
   const searchUrl = $<HTMLInputElement>("#setup-search-url");
-  const privateSearchUrl = $<HTMLInputElement>("#setup-private-search-url");
   const suggestUrl = $<HTMLInputElement>("#setup-suggest-url");
   const browserTabs = $("#setup-browser-tabs");
   const browserPanel = $("#setup-browser-panel");
@@ -147,7 +146,6 @@ export function setupAddressBarSheet(
   let activeBrowser: AddressBarBrowser | null = null;
 
   searchUrl.value = `${location.origin}?q=%s`;
-  privateSearchUrl.value = `${location.origin}/#q=%s`;
   suggestUrl.value = `${location.origin}/suggest?q=%s`;
 
   function refreshSuggestionUrl(): void {
@@ -325,7 +323,6 @@ export function setupAddressBarSheet(
 
   for (const [buttonId, input] of [
     ["#copy-search-url", searchUrl],
-    ["#copy-private-search-url", privateSearchUrl],
     ["#copy-suggest-url", suggestUrl],
   ] as const) {
     const button = $<HTMLButtonElement>(buttonId);

--- a/src/ui/home/index.html
+++ b/src/ui/home/index.html
@@ -177,7 +177,7 @@
             <label
               for="setup-search-url"
               class="mb-1.5 block text-xs font-medium text-text-secondary"
-              >Fast Search URL</label
+              >Search URL</label
             >
             <div class="flex items-center gap-2">
               <input
@@ -189,46 +189,13 @@
               <button
                 type="button"
                 id="copy-search-url"
-                data-label="Fast Search URL"
+                data-label="Search URL"
                 class="btn setup-copy inline-flex min-w-20 shrink-0 items-center justify-center gap-1.5 px-3 py-2.5"
-                aria-label="Copy fast search URL"
+                aria-label="Copy search URL"
               >
                 <span data-copy-label>Copy</span>
               </button>
             </div>
-          </div>
-
-          <div>
-            <label
-              for="setup-private-search-url"
-              class="mb-1.5 block text-xs font-medium text-text-secondary"
-              >Private Search URL
-              <span class="font-normal opacity-70"
-                >(slightly slower)</span
-              ></label
-            >
-            <div class="flex items-center gap-2">
-              <input
-                type="text"
-                id="setup-private-search-url"
-                readonly
-                class="input-field min-w-0 flex-1 font-mono text-xs"
-              >
-              <button
-                type="button"
-                id="copy-private-search-url"
-                data-label="Private Search URL"
-                class="btn setup-copy inline-flex min-w-20 shrink-0 items-center justify-center gap-1.5 px-3 py-2.5"
-                aria-label="Copy private search URL"
-              >
-                <span data-copy-label>Copy</span>
-              </button>
-            </div>
-            <p class="mt-1.5 text-xs leading-relaxed text-text-secondary">
-              Keeps submitted queries in the URL fragment, so search navigations
-              do not send them to the Flashbang host. Leave Suggestions URL
-              unset to keep address-bar input local too.
-            </p>
           </div>
 
           <div>

--- a/tests/e2e/flashbang.e2e.ts
+++ b/tests/e2e/flashbang.e2e.ts
@@ -586,15 +586,11 @@ test("compact address-bar setup exposes browser instructions and copyable URLs",
   await page.setViewportSize({ width: 390, height: 780 });
   await openHome(page);
 
-  await expect(page.locator("#setup-url")).toHaveCount(0);
   await page.click("#open-setup");
   const modal = page.locator("#setup-modal");
   await expect(modal).toHaveAttribute("aria-hidden", "false");
   await expect(page.locator("#setup-search-url")).toHaveValue(
     `${new URL(page.url()).origin}?q=%s`
-  );
-  await expect(page.locator("#setup-private-search-url")).toHaveValue(
-    `${new URL(page.url()).origin}/#q=%s`
   );
   const baseSuggestUrl = `${new URL(page.url()).origin}/suggest?q=%s`;
   await expect(page.locator("#setup-suggest-url")).toHaveValue(
@@ -693,16 +689,6 @@ test("compact address-bar setup exposes browser instructions and copyable URLs",
   await expect(page.locator("#copy-search-url [data-copy-label]")).toHaveText(
     "Copied"
   );
-
-  await page.click("#copy-private-search-url");
-  await expect
-    .poll(() =>
-      page.evaluate(
-        () =>
-          (window as typeof window & { copiedSetupUrl?: string }).copiedSetupUrl
-      )
-    )
-    .toBe(`${new URL(page.url()).origin}/#q=%s`);
 
   await page.keyboard.press("Escape");
   await expect(modal).toHaveAttribute("aria-hidden", "true");


### PR DESCRIPTION
The fragment-based template is significantly slower and only useful when query text must stay local, so the setup flow should steer users toward the standard search URL and leave the privacy-sensitive option as an advanced documented fallback.