### PR TITLE
feat(sw): personalize hot boot redirects from top frecency bangs

### DIFF
--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,4 +1,5 @@
 export const TOP_K = 8;
+export const TOP_FRECENCY_ENTRIES = 8;
 export const MAX_FRECENCY_ENTRIES = 64;
 export const FRECENCY_BOOST_MULTIPLIER = 10;
 export const FRECENCY_BOOST_CAP = 2000;

--- a/src/sw/hot-redirect.ts
+++ b/src/sw/hot-redirect.ts
@@ -5,8 +5,11 @@ import {
   HOT_TRIGGERS,
   lookupHotBang,
 } from "../generated/bangs-hot.js";
+import { TOP_FRECENCY_ENTRIES } from "../shared/constants";
 import { validateCustomTrigger } from "../shared/custom-trigger";
+import { hashFNV1a } from "../shared/hash";
 import { HOT_BOOT_SENTINEL, HOT_BOOT_VERSION } from "../shared/hot-boot";
+import { lookupBang } from "./bang-data";
 import {
   type CustomUrlParts,
   compileTriggerSyntax,
@@ -23,9 +26,13 @@ export { HOT_BOOT_SENTINEL };
 export const NO_HOT_BOOT = -1;
 
 let resolvedHotId = -1;
+let resolvedFrecencyTrigger = "";
+
+export type HotFrecencyEntry = readonly [string, UrlParts];
 
 export interface HotBootRecord {
   defaultBang: string;
+  frecency: Readonly<Record<string, UrlParts>> | null;
   payloadComplete: boolean;
   settings: RedirectSettings | null;
   state: number;
@@ -137,6 +144,7 @@ function isSimpleCustom(value: unknown): value is CustomUrlParts {
 
 function decodeBootSettings(encoded: string): {
   defaultBang: string;
+  frecency: Readonly<Record<string, UrlParts>>;
   settings: RedirectSettings;
 } | null {
   const decoded = decodeBase64Url(encoded);
@@ -149,10 +157,11 @@ function decodeBootSettings(encoded: string): {
   } catch {
     return null;
   }
-  if (!Array.isArray(value) || value.length !== 5) {
+  if (!Array.isArray(value) || value.length !== 6) {
     return null;
   }
-  const [defaultBang, defaultUrl, luckyUrl, markers, entries] = value;
+  const [defaultBang, defaultUrl, luckyUrl, markers, entries, frecencyEntries] =
+    value;
   if (
     typeof defaultBang !== "string" ||
     !defaultBang ||
@@ -165,7 +174,9 @@ function decodeBootSettings(encoded: string): {
       (marker) => Number.isInteger(marker) && isBangMarker(marker)
     ) ||
     markers[0] === markers[1] ||
-    !Array.isArray(entries)
+    !Array.isArray(entries) ||
+    !Array.isArray(frecencyEntries) ||
+    frecencyEntries.length > TOP_FRECENCY_ENTRIES
   ) {
     return null;
   }
@@ -185,6 +196,23 @@ function decodeBootSettings(encoded: string): {
     custom[item[0]] = item[1];
   }
 
+  const frecency = Object.create(null) as Record<string, UrlParts>;
+  for (const item of frecencyEntries) {
+    if (
+      !Array.isArray(item) ||
+      item.length !== 2 ||
+      typeof item[0] !== "string" ||
+      validateCustomTrigger(item[0]) !== null ||
+      Object.hasOwn(custom, item[0]) ||
+      Object.hasOwn(frecency, item[0]) ||
+      lookupHotBang(item[0], 0, item[0].length) !== -1 ||
+      !isUrlParts(item[1])
+    ) {
+      return null;
+    }
+    frecency[item[0]] = item[1];
+  }
+
   const syntax = compileTriggerSyntax(
     String.fromCharCode(markers[0]) as Parameters<
       typeof compileTriggerSyntax
@@ -195,6 +223,7 @@ function decodeBootSettings(encoded: string): {
   );
   return {
     defaultBang,
+    frecency,
     settings: {
       custom,
       defaultUrl,
@@ -206,7 +235,8 @@ function decodeBootSettings(encoded: string): {
 
 function encodeBootSettings(
   snapshot: RedirectSettingsSnapshot,
-  settings: RedirectSettings
+  settings: RedirectSettings,
+  frecency: readonly HotFrecencyEntry[]
 ): string {
   const custom = Object.keys(snapshot.custom)
     .sort()
@@ -224,8 +254,30 @@ function encodeBootSettings(
       settings.luckyUrl,
       markers,
       custom,
+      frecency.slice(0, TOP_FRECENCY_ENTRIES),
     ])
   );
+}
+
+export function materializeHotFrecency(
+  counts: Readonly<Record<string, number>>,
+  snapshot: RedirectSettingsSnapshot
+): HotFrecencyEntry[] {
+  const entries: HotFrecencyEntry[] = [];
+  for (const trigger of Object.keys(counts)) {
+    if (
+      entries.length >= TOP_FRECENCY_ENTRIES ||
+      Object.hasOwn(snapshot.custom, trigger) ||
+      lookupHotBang(trigger, 0, trigger.length) !== -1
+    ) {
+      continue;
+    }
+    const parts = lookupBang(trigger, hashFNV1a(trigger));
+    if (parts && isUrlParts(parts)) {
+      entries.push([trigger, [parts[0], parts[1]]]);
+    }
+  }
+  return entries;
 }
 
 export function createHotBootState(snapshot: RedirectSettingsSnapshot): number {
@@ -243,13 +295,14 @@ export function encodeHotBootRecord(
   cacheName: string,
   state: number,
   snapshot?: RedirectSettingsSnapshot,
-  settings?: RedirectSettings
+  settings?: RedirectSettings,
+  frecency: readonly HotFrecencyEntry[] = []
 ): string {
   const compact = `${HOT_BOOT_VERSION}|${cacheName}|${state.toString(36)}`;
   if (!(snapshot && settings)) {
     return compact;
   }
-  const record = `${compact}|${encodeBootSettings(snapshot, settings)}`;
+  const record = `${compact}|${encodeBootSettings(snapshot, settings, frecency)}`;
   return record.length <= MAX_HOT_BOOT_RECORD_LENGTH ? record : `${compact}|-`;
 }
 
@@ -278,6 +331,7 @@ export function decodeHotBootRecord(
     return null;
   }
   let defaultBang = "";
+  let frecency: Readonly<Record<string, UrlParts>> | null = null;
   let settings: RedirectSettings | null = null;
   let payloadComplete = false;
   if (payloadStart !== -1) {
@@ -289,10 +343,11 @@ export function decodeHotBootRecord(
         return null;
       }
       defaultBang = decoded.defaultBang;
+      frecency = decoded.frecency;
       settings = decoded.settings;
     }
   }
-  return { defaultBang, payloadComplete, settings, state: packed };
+  return { defaultBang, frecency, payloadComplete, settings, state: packed };
 }
 
 export function hotBootSettingsNeedPublish(
@@ -302,12 +357,15 @@ export function hotBootSettingsNeedPublish(
 }
 
 export function getResolvedHotTrigger(): string {
-  return HOT_TRIGGERS[resolvedHotId];
+  return resolvedHotId === -1
+    ? resolvedFrecencyTrigger
+    : HOT_TRIGGERS[resolvedHotId];
 }
 
 export function resolveHotRedirect(
   rawQuery: string,
-  state: number
+  state: number,
+  frecency?: Readonly<Record<string, UrlParts>> | null
 ): string | null {
   resolvedHotId = -1;
   if (state < 0) {
@@ -353,8 +411,24 @@ export function resolveHotRedirect(
   }
 
   const id = lookupHotBang(rawQuery, triggerStart, separator);
-  if (id < 0 || (state & (1 << id)) !== 0) {
-    return null;
+  let prefix: string;
+  let suffix: string | null;
+  if (id >= 0) {
+    if ((state & (1 << id)) !== 0) {
+      return null;
+    }
+    resolvedHotId = id;
+    prefix = HOT_PREFIXES[id];
+    suffix = HOT_SUFFIXES[id];
+  } else {
+    const trigger = rawQuery.substring(triggerStart, separator);
+    const parts = frecency?.[trigger];
+    if (!parts) {
+      return null;
+    }
+    resolvedFrecencyTrigger = trigger;
+    prefix = parts[0];
+    suffix = parts[1];
   }
 
   const termStart = separator + separatorWidth;
@@ -379,8 +453,7 @@ export function resolveHotRedirect(
     return null;
   }
 
-  resolvedHotId = id;
-  return (
-    HOT_PREFIXES[id] + rawQuery.substring(termStart, termEnd) + HOT_SUFFIXES[id]
-  );
+  return suffix === null
+    ? prefix
+    : prefix + rawQuery.substring(termStart, termEnd) + suffix;
 }

--- a/src/sw/idb.ts
+++ b/src/sw/idb.ts
@@ -1,6 +1,7 @@
 import {
   FRECENCY_HALF_LIFE_MS,
   MAX_FRECENCY_ENTRIES,
+  TOP_FRECENCY_ENTRIES,
 } from "../shared/constants";
 import {
   parseFrecencyCompact,
@@ -20,8 +21,6 @@ import {
   prepareRedirectSettings,
   type RedirectSettingsSnapshot,
 } from "./redirect-settings";
-
-const FRECENCY_COOKIE_ENTRIES = 8;
 
 interface FrecencySnapshot {
   counts: Record<string, number> | null;
@@ -244,7 +243,7 @@ function hydrateFrecency(stored: string | undefined): void {
   const decayed = applyDecay();
   const pruned = pruneFrecency();
   shouldPersist = decayed || pruned || shouldPersist;
-  topFrecency = buildTopFrecency(frecencyCounts, FRECENCY_COOKIE_ENTRIES);
+  topFrecency = buildTopFrecency(frecencyCounts, TOP_FRECENCY_ENTRIES);
   if (shouldPersist) {
     void persistFrecencySnapshot(frecencyCounts, lastDecayTs);
   }
@@ -290,6 +289,7 @@ export function loadFrecency(): Promise<void> {
 
 export function trackBangUsage(trigger: string): {
   persistence: Promise<void>;
+  topMembershipChanged: boolean;
   topChanged: boolean;
 } {
   if (!frecencyCounts) {
@@ -299,17 +299,20 @@ export function trackBangUsage(trigger: string): {
   if (!lastDecayTs) {
     lastDecayTs = Date.now();
   }
+  const wasTop = topFrecency.some((entry) => entry.trigger === trigger);
   const nextCount = (frecencyCounts[trigger] || 0) + 1;
   frecencyCounts[trigger] = nextCount;
   updateTopFrecencyOnIncrement(
     topFrecency,
     trigger,
     nextCount,
-    FRECENCY_COOKIE_ENTRIES
+    TOP_FRECENCY_ENTRIES
   );
   pruneFrecency();
+  const topChanged = topFrecency.some((entry) => entry.trigger === trigger);
   return {
     persistence: persistFrecencySnapshot(frecencyCounts, lastDecayTs),
-    topChanged: topFrecency.some((entry) => entry.trigger === trigger),
+    topMembershipChanged: !wasTop && topChanged,
+    topChanged,
   };
 }

--- a/src/sw/sw.ts
+++ b/src/sw/sw.ts
@@ -18,6 +18,7 @@ import {
   HOT_BOOT_SENTINEL,
   type HotBootRecord,
   hotBootSettingsNeedPublish,
+  materializeHotFrecency,
   NO_HOT_BOOT,
   resolveHotRedirect,
 } from "./hot-redirect";
@@ -135,11 +136,21 @@ async function publishHotBoot(includeSettings = false): Promise<void> {
   const state = createHotBootState(snapshot);
   let settings: RedirectSettings | undefined;
   if (includeSettings && isBangDataInitialized()) {
+    await loadFrecency();
     settings =
       getCachedSettings() ??
       (await readRedirectSettings(Promise.resolve(snapshot)));
   }
-  const record = encodeHotBootRecord(CACHE_NAME, state, snapshot, settings);
+  const frecency = settings
+    ? materializeHotFrecency(getTopFrecencyRecord(), snapshot)
+    : undefined;
+  const record = encodeHotBootRecord(
+    CACHE_NAME,
+    state,
+    snapshot,
+    settings,
+    frecency
+  );
   await navigationPreload.disable();
   await navigationPreload.setHeaderValue(record);
   const decoded = decodeHotBootRecord(record, CACHE_NAME);
@@ -370,12 +381,22 @@ function queueBangSideEffects(e: FetchEvent, trigger: string): void {
     loadFrecency()
       .then(() => {
         const usage = trackBangUsage(trigger);
+        const hotBootSync =
+          usage.topMembershipChanged && isBangDataInitialized()
+            ? queueHotBootMutation(() => publishHotBoot(true)).catch(
+                swallowError
+              )
+            : RESOLVED_PROMISE;
         if (typeof cookieStore === "undefined" || !usage.topChanged) {
-          return usage.persistence;
+          return Promise.all([usage.persistence, hotBootSync]).then(
+            () => undefined
+          );
         }
 
         if (!hasTopFrecency()) {
-          return usage.persistence;
+          return Promise.all([usage.persistence, hotBootSync]).then(
+            () => undefined
+          );
         }
         const frecency = getTopFrecencyRecord();
         const cookieSync = cookieStore
@@ -402,7 +423,7 @@ function queueBangSideEffects(e: FetchEvent, trigger: string): void {
             });
           })
           .catch(swallowError);
-        return Promise.all([usage.persistence, cookieSync]).then(
+        return Promise.all([usage.persistence, cookieSync, hotBootSync]).then(
           () => undefined
         );
       })
@@ -702,7 +723,8 @@ self.addEventListener("fetch", (e: FetchEvent) => {
             if (e.request.mode === "navigate") {
               const hotUrl = resolveHotRedirect(
                 rawQ,
-                hotBoot?.state ?? NO_HOT_BOOT
+                hotBoot?.state ?? NO_HOT_BOOT,
+                hotBoot?.frecency
               );
               if (hotUrl) {
                 queueBangSideEffects(e, getResolvedHotTrigger());

--- a/tests/e2e/flashbang.e2e.ts
+++ b/tests/e2e/flashbang.e2e.ts
@@ -1835,6 +1835,9 @@ test("rich hot boot redirects without IndexedDB or bang data", async ({
   await context.route("https://startpage.com/**", (route) =>
     route.fulfill({ body: "ok", contentType: "text/plain", status: 200 })
   );
+  await context.route("https://www.npmjs.com/**", (route) =>
+    route.fulfill({ body: "ok", contentType: "text/plain", status: 200 })
+  );
   await ensureWarmController(page);
   await seedCustomBangs(page, [
     {
@@ -1877,6 +1880,26 @@ test("rich hot boot redirects without IndexedDB or bang data", async ({
     )
     .toMatch(/^h1\|fb-[^|]+\|[^|]+\|/);
 
+  const headerBeforeFrecency = await page.evaluate(async () => {
+    const state = await (
+      await navigator.serviceWorker.ready
+    ).navigationPreload.getState();
+    return state.headerValue;
+  });
+  await page.evaluate(() =>
+    fetch("/?q=%21npm%20preload", { redirect: "manual" })
+  );
+  await expect
+    .poll(() =>
+      page.evaluate(async () => {
+        const state = await (
+          await navigator.serviceWorker.ready
+        ).navigationPreload.getState();
+        return state.headerValue;
+      })
+    )
+    .not.toBe(headerBeforeFrecency);
+
   await page.evaluate(async () => {
     for (const name of await caches.keys()) {
       const cache = await caches.open(name);
@@ -1905,7 +1928,13 @@ test("rich hot boot redirects without IndexedDB or bang data", async ({
   await context.route(`${origin}/**`, (route) => route.abort());
   await navigateAndWaitForRedirect(
     page,
-    "/?q=%21mine%20hello",
+    "/?q=%21npm%20router",
+    /npmjs\.com\/search\?q=router/
+  );
+  const customPage = await context.newPage();
+  await navigateAndWaitForRedirect(
+    customPage,
+    `${origin}/?q=%21mine%20hello`,
     /example\.com\/search\?q=hello/
   );
   const defaultPage = await context.newPage();

--- a/tests/hot-redirect.test.ts
+++ b/tests/hot-redirect.test.ts
@@ -9,6 +9,7 @@ import {
   getResolvedHotTrigger,
   hotBootSettingsNeedPublish,
   MAX_HOT_BOOT_RECORD_LENGTH,
+  materializeHotFrecency,
   NO_HOT_BOOT,
   parseHotBootRecord,
   resolveHotRedirect,
@@ -102,6 +103,7 @@ describe("service worker hot redirects", () => {
     const decoded = decodeHotBootRecord(record, "fb-test")!;
     expect(decoded.state).toBe(state);
     expect(decoded.defaultBang).toBe("sp");
+    expect(decoded.frecency).toEqual({});
     expect(hotBootSettingsNeedPublish(decoded)).toBe(false);
     expect(decoded.settings!.custom.regex).toBeUndefined();
     expect(redirectRawUrl("regular+query", decoded.settings!)).toBe(
@@ -113,6 +115,57 @@ describe("service worker hot redirects", () => {
     expect(redirectRawUrl("@docs+service+workers", decoded.settings!)).toBe(
       "https://startpage.com/do/metasearch.pl?query=service+workers+site:docs.example"
     );
+  });
+
+  test("round-trips and resolves eligible personalized frecency bangs", () => {
+    const sourceSnapshot = snapshot();
+    const sourceSettings = settings();
+    const frecency = materializeHotFrecency(
+      { npm: 9, gh: 8, missing: 7 },
+      sourceSnapshot
+    );
+    expect(frecency.map(([trigger]) => trigger)).toEqual(["npm"]);
+
+    const state = createHotBootState(sourceSnapshot);
+    const record = encodeHotBootRecord(
+      "fb-test",
+      state,
+      sourceSnapshot,
+      sourceSettings,
+      frecency
+    );
+    const decoded = decodeHotBootRecord(record, "fb-test")!;
+    expect(Object.keys(decoded.frecency!)).toEqual(["npm"]);
+    expect(
+      resolveHotRedirect(";npm+react%20router", state, decoded.frecency)
+    ).toBe(redirectRawUrl(";npm+react%20router", sourceSettings));
+    expect(getResolvedHotTrigger()).toBe("npm");
+
+    const custom = Object.assign(Object.create(null), {
+      npm: ["https://custom.example/?q=", ""],
+    }) as Record<string, CustomUrlParts>;
+    expect(materializeHotFrecency({ npm: 9 }, snapshot(custom))).toEqual([]);
+  });
+
+  test("caps personalized frecency payloads at eight entries", () => {
+    const sourceSnapshot = snapshot();
+    const state = createHotBootState(sourceSnapshot);
+    const frecency = Array.from(
+      { length: 9 },
+      (_, index) =>
+        [`personal${index}`, [`https://example.com/${index}?q=`, ""]] as const
+    );
+    const decoded = decodeHotBootRecord(
+      encodeHotBootRecord(
+        "fb-test",
+        state,
+        sourceSnapshot,
+        settings(),
+        frecency
+      ),
+      "fb-test"
+    )!;
+    expect(Object.keys(decoded.frecency!)).toHaveLength(8);
   });
 
   test("drops the complete rich payload rather than truncating oversized settings", () => {

--- a/tests/sw-idb.test.ts
+++ b/tests/sw-idb.test.ts
@@ -424,9 +424,12 @@ describe("sw/idb frecency", () => {
     const mod = await loadSwIdb();
     await mod.loadFrecency();
 
-    mod.trackBangUsage("yt");
-    mod.trackBangUsage("yt");
-    mod.trackBangUsage("g");
+    const firstYt = mod.trackBangUsage("yt");
+    const secondYt = mod.trackBangUsage("yt");
+    const firstG = mod.trackBangUsage("g");
+    expect(firstYt.topMembershipChanged).toBe(true);
+    expect(secondYt.topMembershipChanged).toBe(false);
+    expect(firstG.topMembershipChanged).toBe(true);
     expect(mod.getTopFrecencyRecord()).toEqual({ yt: 2, g: 1 });
 
     mod.invalidateCache();

--- a/tests/sw-runtime.test.ts
+++ b/tests/sw-runtime.test.ts
@@ -603,6 +603,34 @@ describe("sw runtime with real modules", () => {
     expect(navigationPreloadWrites).toContain(HOT_BOOT_SENTINEL);
   });
 
+  test("publishes a personalized hot entry when top-eight membership changes", async () => {
+    const state: NavigationPreloadState = {
+      enabled: false,
+      headerValue: "true",
+    };
+    await loadSwRuntime([], false, state);
+
+    const activate = createExtendableEvent();
+    await handlers.activate?.(activate.event);
+    await Promise.all(activate.waits);
+
+    const fetchEvt = createFetchEvent(
+      "https://flashbang.local/?q=!npm+react",
+      "",
+      "navigate"
+    );
+    await handlers.fetch?.(fetchEvt.event);
+    const response = await fetchEvt.response();
+    expect(response.headers.get("Location")).toContain("npmjs.com");
+    await Promise.all(fetchEvt.waits);
+
+    const record = decodeHotBootRecord(state.headerValue, "fb-test-cache")!;
+    expect(Object.keys(record.frecency!)).toContain("npm");
+    expect(
+      resolveHotRedirect("!npm+router", record.state, record.frecency)
+    ).toBe(redirectRawUrl("!npm+router", record.settings!));
+  });
+
   test("keeps hot-boot metadata disabled until concurrent writes finish", async () => {
     const state: NavigationPreloadState = {
       enabled: false,


### PR DESCRIPTION
Include the top frecency non-custom bangs in the hot-boot payload so navigations can still resolve recently used triggers before IndexedDB or bang data are available.

Also publish hot-boot updates when top-eight membership changes, keeping the preload header aligned with the user's most relevant bangs.