### PR TITLE
perf(sw): keep trigger blob byte-backed

### DIFF
--- a/scripts/codegen.ts
+++ b/scripts/codegen.ts
@@ -508,8 +508,6 @@ interface PackedBangData {
   entryCount: number;
   prefixIds: number[];
   suffixIdsPlusOne: number[];
-  triggerBlob: ReturnType<typeof packBlob>;
-  triggerLensKind: "u8" | "u16";
   triggers: string[];
   uniquePrefixes: string[];
   uniqueSuffixes: string[];
@@ -582,15 +580,8 @@ function packBangData(bangs: Bang[]): PackedBangData {
     }
   }
 
-  const triggerBlob = packBlob(triggers);
   const prefixBlob = packBlob(uniquePrefixes);
   const suffixBlob = packBlob(uniqueSuffixes);
-
-  const triggerMaxLen = triggerBlob.lengths.reduce(
-    (max, len) => (len > max ? len : max),
-    0
-  );
-  const triggerLensKind = triggerMaxLen <= 0xff ? "u8" : "u16";
   for (const len of prefixBlob.lengths) {
     if (len > 0xffff) {
       throw new Error(
@@ -608,8 +599,6 @@ function packBangData(bangs: Bang[]): PackedBangData {
 
   return {
     entryCount,
-    triggerBlob,
-    triggerLensKind,
     prefixBlob,
     suffixBlob,
     prefixIds,
@@ -652,10 +641,25 @@ function generateBinary(bangs: readonly Bang[]): Uint8Array {
   const triggerBytes = encoder.encode(triggerBlob.blob);
   const prefixBytes = encoder.encode(packed.prefixBlob.blob);
   const suffixBytes = encoder.encode(packed.suffixBlob.blob);
+  const triggerByteLengths = triggers.map(
+    (trigger) => encoder.encode(trigger).byteLength
+  );
+  const triggerMaxLength = Math.max(...triggerByteLengths);
+  if (triggerMaxLength > 0x7fff) {
+    throw new Error(
+      `Binary bang format requires encoded trigger length <= 32767, got ${triggerMaxLength}`
+    );
+  }
+  const triggerLengthWidth = triggerMaxLength <= 0x7f ? 1 : 2;
+  const nonAsciiFlag = triggerLengthWidth === 1 ? 0x80 : 0x8000;
   const triggerLengths =
-    packed.triggerLensKind === "u8"
-      ? Uint8Array.from(triggerBlob.lengths)
-      : Uint16Array.from(triggerBlob.lengths);
+    triggerLengthWidth === 1
+      ? Uint8Array.from(triggerByteLengths, (length, index) =>
+          length === triggers[index].length ? length : length | nonAsciiFlag
+        )
+      : Uint16Array.from(triggerByteLengths, (length, index) =>
+          length === triggers[index].length ? length : length | nonAsciiFlag
+        );
   // URL blobs stay byte-backed in the worker and are decoded one entry at a time.
   const prefixLengths = Uint16Array.from(packed.uniquePrefixes, (value) => {
     const length = encoder.encode(value).byteLength;
@@ -696,10 +700,10 @@ function generateBinary(bangs: readonly Bang[]): Uint8Array {
   const output = new Uint8Array(new ArrayBuffer(totalBytes));
   new Uint32Array(output.buffer, 0, headerWords).set([
     0x31424246,
-    3,
+    4,
     packed.entryCount,
     mph.displacements.length,
-    packed.triggerLensKind === "u8" ? 1 : 2,
+    triggerLengths.BYTES_PER_ELEMENT,
     packed.uniquePrefixes.length,
     packed.uniqueSuffixes.length,
     triggerBytes.byteLength,

--- a/src/sw/bang-data.ts
+++ b/src/sw/bang-data.ts
@@ -1,8 +1,8 @@
 export type BuiltinUrlParts = readonly [string, string | null];
 
 const MAGIC = 0x31424246;
-// Version 3 stores prefix/suffix lengths as UTF-8 bytes for lazy decoding.
-const VERSION = 3;
+// Version 4 stores blob lengths as UTF-8 bytes and flags non-ASCII triggers.
+const VERSION = 4;
 const HEADER_WORDS = 13;
 const HEADER_BYTES = HEADER_WORDS * Uint32Array.BYTES_PER_ELEMENT;
 const MPH_SLOT_MULTIPLIER = 0x85ebca6b;
@@ -11,15 +11,37 @@ let lookup: ((trigger: string, hash: number) => BuiltinUrlParts | null) | null =
   null;
 const BANG_DATA_UNAVAILABLE = new Error("Binary bang data is not initialized");
 
-function offsets(lengths: Uint8Array | Uint16Array): Uint32Array {
+function offsets(
+  lengths: Uint8Array | Uint16Array,
+  lengthMask = 0xffff
+): Uint32Array {
   const result = new Uint32Array(lengths.length + 1);
   let position = 0;
   for (let i = 0; i < lengths.length; i++) {
     result[i] = position;
-    position += lengths[i];
+    position += lengths[i] & lengthMask;
   }
   result[lengths.length] = position;
   return result;
+}
+
+function matchesTrigger(
+  raw: string,
+  rawStart: number,
+  bytes: Uint8Array,
+  byteStart: number,
+  length: number
+): boolean {
+  for (let i = 0; i < length; i++) {
+    let code = raw.charCodeAt(rawStart + i);
+    if (code >= 65 && code <= 90) {
+      code |= 32;
+    }
+    if (code !== bytes[byteStart + i]) {
+      return false;
+    }
+  }
+  return true;
 }
 
 export function initializeBangData(buffer: ArrayBuffer): void {
@@ -34,6 +56,7 @@ export function initializeBangData(buffer: ArrayBuffer): void {
   const entryCount = header[2];
   const bucketCount = header[3];
   const triggerLengthWidth = header[4];
+  const triggerLengthMask = triggerLengthWidth === 1 ? 0x7f : 0x7fff;
   const prefixCount = header[5];
   const suffixCount = header[6];
   const displacementWidth = header[12];
@@ -80,13 +103,16 @@ export function initializeBangData(buffer: ArrayBuffer): void {
   }
 
   const decoder = new TextDecoder();
-  const triggerBlob = decoder.decode(new Uint8Array(buffer, offset, header[7]));
+  const triggerBlob = new Uint8Array(buffer, offset, header[7]);
   offset += header[7];
   const prefixBlob = new Uint8Array(buffer, offset, header[8]);
   offset += header[8];
   const suffixBlob = new Uint8Array(buffer, offset, header[9]);
 
-  const triggerOffsets = offsets(triggerLengths);
+  const triggerOffsets = offsets(triggerLengths, triggerLengthMask);
+  if (triggerOffsets[entryCount] !== triggerBlob.length) {
+    throw new Error("Invalid binary bang trigger lengths");
+  }
   const prefixOffsets = offsets(prefixLengths);
   const suffixOffsets = offsets(suffixLengths);
   const prefixCache: string[] = [];
@@ -140,8 +166,17 @@ export function initializeBangData(buffer: ArrayBuffer): void {
         : (Math.imul(unsignedHash ^ (displacement + 1), MPH_SLOT_MULTIPLIER) >>>
             0) %
           entryCount;
-    return triggerLengths[index] === trigger.length &&
-      triggerBlob.startsWith(trigger, triggerOffsets[index])
+    const triggerInfo = triggerLengths[index];
+    const triggerLength = triggerInfo & triggerLengthMask;
+    const triggerStart = triggerOffsets[index];
+    const triggerEnd = triggerOffsets[index + 1];
+    return (
+      triggerInfo === triggerLength
+        ? triggerLength === trigger.length &&
+          matchesTrigger(trigger, 0, triggerBlob, triggerStart, triggerLength)
+        : decoder.decode(triggerBlob.subarray(triggerStart, triggerEnd)) ===
+          trigger
+    )
       ? tuple(index)
       : null;
   };

--- a/tests/codegen-roundtrip.test.ts
+++ b/tests/codegen-roundtrip.test.ts
@@ -81,7 +81,7 @@ describe("codegen round-trip", () => {
     const binary = await Bun.file("src/generated/bangs.bin").arrayBuffer();
     const header = new Uint32Array(binary, 0, 13);
     expect(header[0]).toBe(0x31424246);
-    expect(header[1]).toBe(3);
+    expect(header[1]).toBe(4);
     expect(header[2]).toBe(bangs.filter((bang) => !bang.regex).length);
     expect(header[11]).toBe(binary.byteLength);
     expect(header[3] & (header[3] - 1)).toBe(0);


### PR DESCRIPTION
## Summary
- store trigger lengths as UTF-8 byte lengths in binary format v4
- compare ASCII triggers directly against the byte-backed blob
- preserve non-ASCII triggers with a compact length flag and lazy candidate decoding

## Results
- reduces median bang-data initialization from 133.48us to 114.79us
- saves about 168 KiB of retained external memory
- keeps packed lookup performance at about 16ns
- leaves bangs.bin size unchanged

## Verification
- bun test
- bun run typecheck
- bun run check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved bang trigger matching for non-ASCII and international characters.
  - Corrected handling of trigger lengths when encoded characters use multiple bytes.
  - Improved recognition accuracy for triggers with varying lengths, including case-insensitive ASCII matching.

- **Compatibility**
  - Updated the generated binary lookup data format to ensure reliable loading and validation of the latest bang data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->