### PR TITLE
chore(release): prepare v1.6.1

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -1,0 +1,106 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Stable SemVer version without the v prefix
+        required: true
+        type: string
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: prepare-release
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Open release pull request
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: master
+          persist-credentials: false
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Validate version
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$RELEASE_VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "::error::Version '$RELEASE_VERSION' must match strict stable SemVer X.Y.Z." >&2
+            exit 1
+          fi
+          if git ls-remote --exit-code --tags origin "refs/tags/v$RELEASE_VERSION" >/dev/null 2>&1; then
+            echo "::error::Tag 'v$RELEASE_VERSION' already exists." >&2
+            exit 1
+          fi
+
+          current_version="$(bun -e 'const p = await Bun.file("package.json").json(); process.stdout.write(p.version);')"
+          IFS=. read -r current_major current_minor current_patch <<< "$current_version"
+          IFS=. read -r release_major release_minor release_patch <<< "$RELEASE_VERSION"
+          if (( release_major < current_major ||
+                (release_major == current_major && release_minor < current_minor) ||
+                (release_major == current_major && release_minor == current_minor && release_patch <= current_patch) )); then
+            echo "::error::Version '$RELEASE_VERSION' must be greater than package.json version '$current_version'." >&2
+            exit 1
+          fi
+
+      - name: Update repository versions
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          bun -e '
+            const version = process.env.RELEASE_VERSION;
+            const packageJson = await Bun.file("package.json").json();
+            packageJson.version = version;
+            await Bun.write("package.json", `${JSON.stringify(packageJson, null, 2)}\n`);
+
+            const readme = await Bun.file("README.md").text();
+            const marker = /<!-- release-version -->[\s\S]*?<!-- \/release-version -->/;
+            if (!marker.test(readme)) {
+              throw new Error("README.md release version marker is missing");
+            }
+            const block = `<!-- release-version -->\n<p align="center"><strong>Current release: <a href="https://github.com/${process.env.GITHUB_REPOSITORY}/releases/tag/v${version}">v${version}</a></strong></p>\n<!-- /release-version -->`;
+            await Bun.write("README.md", readme.replace(marker, block));
+          '
+
+      - name: Commit and open pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          branch="automation/release-v$RELEASE_VERSION"
+          if git ls-remote --exit-code --heads origin "refs/heads/$branch" >/dev/null 2>&1; then
+            echo "::error::Release branch '$branch' already exists." >&2
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git switch -c "$branch"
+          git add package.json README.md
+          git commit -m "chore(release): prepare v$RELEASE_VERSION"
+
+          gh auth setup-git
+          git push --set-upstream origin "$branch"
+          pr_url="$(gh pr create --repo "$GITHUB_REPOSITORY" \
+            --base master \
+            --head "$branch" \
+            --title "chore(release): prepare v$RELEASE_VERSION" \
+            --body "Automated package and README version bump for v$RELEASE_VERSION.")"
+          gh workflow run ci.yaml --repo "$GITHUB_REPOSITORY" --ref "$branch"
+          gh pr merge "$pr_url" --repo "$GITHUB_REPOSITORY" \
+            --auto \
+            --merge \
+            --delete-branch

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           bun-version: 1.3.14
 
-      - name: Validate release tag and package version
+      - name: Validate release tag and repository versions
         env:
           RELEASE_TAG: ${{ github.ref_name }}
         run: |
@@ -34,6 +34,12 @@ jobs:
           package_version="$(bun -e 'const p = await Bun.file("package.json").json(); if (typeof p.version !== "string") { console.error("package.json version must be a string"); process.exit(1); } process.stdout.write(p.version);')"
           if [ "$tag_version" != "$package_version" ]; then
             echo "::error::Release tag version '$tag_version' does not match package.json version '$package_version'." >&2
+            exit 1
+          fi
+
+          readme_version="$(bun -e 'const text = await Bun.file("README.md").text(); const match = text.match(/Current release:.*?>v([0-9]+\.[0-9]+\.[0-9]+)<\/a>/); if (!match) { console.error("README.md current release marker is missing"); process.exit(1); } process.stdout.write(match[1]);')"
+          if [ "$tag_version" != "$readme_version" ]; then
+            echo "::error::Release tag version '$tag_version' does not match README.md version '$readme_version'." >&2
             exit 1
           fi
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ The repository custom-bang file supports simple `{}` templates plus the special 
 We use **GitHub Releases** as the canonical place for release notes and version history.
 
 - Version tags must use strict stable SemVer `vX.Y.Z` (for example `v1.5.0`) and match the version in `package.json`
-- Maintainers push the version commit to `master`, wait for protected-branch CI, then create and push an annotated tag; they do not create the GitHub Release manually
+- Maintainers run the **Prepare Release** workflow to open an automated package/README version-bump pull request, which auto-merges after protected-branch CI; they then create and push an annotated tag and do not create the GitHub Release manually
 - The tag-triggered workflow verifies that the tagged commit is contained in `origin/master`, runs its validation gates without repeating Playwright E2E, and creates the GitHub Release with generated notes
 - After release creation, the workflow health-checks a container and publishes `linux/amd64` and `linux/arm64` images to GHCR with the version and `latest` tags
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -42,6 +42,7 @@ flashbang/
 │   └── workflows/
 │       ├── ci.yaml            # Typecheck, checks, tests, build, and E2E matrix
 │       ├── codeql.yaml         # CodeQL analysis for application and workflow code
+│       ├── prepare-release.yaml # Version-bump pull request automation
 │       ├── release.yaml       # GitHub Release and multi-architecture image publishing
 │       └── update-bangs.yaml  # Daily bang-source refresh
 ├── functions/
@@ -330,24 +331,17 @@ A daily cron workflow (`.github/workflows/update-bangs.yaml`) fetches fresh bang
 
 ## Releasing
 
-1. Update `version` in `package.json`
-2. Run `bun run typecheck`, `bun run check`, `bun audit`, `bun test`, and `bun run build`
-3. Commit and push the version bump so the commit is on `origin/master`:
+1. Run the **Prepare Release** workflow with the stable SemVer version without a `v` prefix. It updates `package.json` and the README release marker together, pushes an `automation/release-vX.Y.Z` branch, opens a pull request, dispatches CI, and enables auto-merge.
+2. Review the generated pull request. It merges automatically after protected-branch checks, including Playwright E2E, pass.
+3. Create and push an annotated tag from the merged `origin/master` commit:
 
 ```sh
-git add package.json
-git commit -m "chore: bump version to X.Y.Z"
-git push origin master
-```
-
-4. Wait for the protected-branch CI checks, including Playwright E2E, to pass for that commit
-5. Create and push an annotated tag from that commit:
-
-```sh
+git switch master
+git pull --ff-only origin master
 git tag -a vX.Y.Z -m "vX.Y.Z"
 git push origin vX.Y.Z
 ```
 
-Do not create the GitHub Release manually. The tag-triggered release workflow (`.github/workflows/release.yaml`) accepts only strict stable `vX.Y.Z` tags, requires the tag version to match `package.json`, and verifies that the tagged commit is contained in `origin/master`. It then runs codegen (`--from-merged`), typecheck, lint/format checks, `bun audit`, the test suite, and the build. It does not rerun Playwright because protected-branch CI already covers E2E.
+Do not create the GitHub Release manually. The tag-triggered release workflow (`.github/workflows/release.yaml`) accepts only strict stable `vX.Y.Z` tags, requires the tag version to match `package.json` and the README release marker, and verifies that the tagged commit is contained in `origin/master`. It then runs codegen (`--from-merged`), typecheck, lint/format checks, `bun audit`, the test suite, and the build. It does not rerun Playwright because protected-branch CI already covers E2E.
 
 After validation succeeds, the workflow creates the GitHub Release with generated notes. It then builds and health-checks a local image before publishing `linux/amd64` and `linux/arm64` images to `ghcr.io/<owner>/flashbang` with both the release version and `latest` tags.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://dash.cloudflare.com/?to=/:account/workers-and-pages) [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/flashbang?referralCode=cxTxcH&utm_medium=integration&utm_source=template&utm_campaign=generic)
 
+<!-- release-version -->
+<p align="center"><strong>Current release: <a href="https://github.com/ph1losof/flashbang/releases/tag/v1.6.1">v1.6.1</a></strong></p>
+<!-- /release-version -->
+
 ![Flashbang](.github/images/landing.png)
 
 <p align="center"><a href="#features">Features</a> &nbsp;|&nbsp; <a href="#bang-syntax">Bang syntax</a> &nbsp;|&nbsp; <a href="#snap-syntax">Snap syntax</a> &nbsp;|&nbsp; <a href="#setup-as-search-engine">Setup</a> &nbsp;|&nbsp; <a href="#deploy-your-own">Self-host</a> &nbsp;|&nbsp; <a href="#how-it-works">How it works</a> &nbsp;|&nbsp; <a href="#contributing">Contributing</a></p>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "flashbang",
   "description": "The sub-1ms local first duck-duck-go style bang redirects",
   "private": true,
-  "version": "1.6.0",
+  "version": "1.6.1",
   "type": "module",
   "packageManager": "bun@1.3.14",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump package metadata and the README release marker to v1.6.1
- add a Prepare Release workflow that opens version-bump PRs, dispatches CI, and enables auto-merge
- require release tags to match both package.json and README.md
- update maintainer release documentation

## Verification
- bun run typecheck
- bun run check
- bun audit
- bun test (490 passed using a clean index; the local shared index contains an unrelated staged experiment)
- bun run build
- YAML parse validation for both release workflows